### PR TITLE
Fix DUPLICATE_KEY_ERR in fetchResourceManagerIamPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to
 - Update to
   [SDK v3.0.0](https://github.com/JupiterOne/sdk/blob/master/packages/integration-sdk/CHANGELOG.md#300---2020-08-24)
 
+### Fixed
+
+- Fixed potential for DUPLICATE_KEY_ERROR in `fetchResourceManagerIamPolicy`
+
 ## 0.3.0 - 2020-08-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 0.4.0 - 2020-09-28
+
 ### Added
 
 - Build relationship between `google_compute_instance` and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google-cloud",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A graph conversion tool for https://cloud.google.com/",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/steps/resource-manager/index.test.ts
+++ b/src/steps/resource-manager/index.test.ts
@@ -7,7 +7,8 @@ import { setupGoogleCloudRecording } from '../../../test/recording';
 import { IntegrationConfig } from '../../types';
 import { fetchResourceManagerIamPolicy } from '.';
 import { integrationConfig } from '../../../test/config';
-import { iamSteps, IAM_USER_ENTITY_TYPE } from '../iam';
+import { iamSteps, IAM_USER_ENTITY_TYPE, IAM_ROLE_ENTITY_TYPE } from '../iam';
+import { ResourceManagerClient } from './client';
 
 async function executeIamSteps(
   context: MockIntegrationStepExecutionContext<IntegrationConfig>,
@@ -28,7 +29,46 @@ describe('#fetchResourceManagerIamPolicy', () => {
   });
 
   afterEach(async () => {
-    await recording.stop();
+    if (recording) {
+      await recording.stop();
+    }
+  });
+
+  test('should only create one user entity when returned multiple times from API', async () => {
+    jest
+      .spyOn(ResourceManagerClient.prototype, 'getServiceAccountPolicy')
+      .mockResolvedValueOnce({
+        bindings: [
+          {
+            role: 'roles/editor',
+            members: ['user:austin.kelleher@jupiterone.io'],
+          },
+          {
+            role: 'roles/owner',
+            members: ['user:austin.kelleher@jupiterone.io'],
+          },
+        ],
+      });
+
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig: integrationConfig,
+    });
+
+    await fetchResourceManagerIamPolicy(context);
+    const iamUserEntities = context.jobState.collectedEntities.filter(
+      (e) => e._type === IAM_USER_ENTITY_TYPE,
+    );
+    expect(iamUserEntities.length).toBe(1);
+    expect(iamUserEntities[0]._key).toBe('austin.kelleher@jupiterone.io');
+
+    const iamRoleEntities = context.jobState.collectedEntities.filter(
+      (e) => e._type === IAM_ROLE_ENTITY_TYPE,
+    );
+    expect(iamRoleEntities.length).toBe(2);
+    expect(iamRoleEntities.map((e) => e._key)).toMatchObject([
+      'roles/editor',
+      'roles/owner',
+    ]);
   });
 
   test('should collect data', async () => {

--- a/src/steps/resource-manager/index.ts
+++ b/src/steps/resource-manager/index.ts
@@ -53,14 +53,21 @@ async function maybeFindOrCreateIamUserEntity({
     // will just ignore it.
     userEntity = await jobState.findEntity(parsedIdentifier);
   } else {
-    userEntity = await jobState.addEntity(
-      createIamUserEntity({
-        type: parsedMemberType,
-        identifier: parsedIdentifier,
-        uniqueid: parsedMember.uniqueid,
-        deleted: parsedMember.deleted,
-      }),
-    );
+    // We always want to find or create relationships to user entities. Since
+    // the same user can have multiple roles, there is a possibility that a
+    // user is created earlier in this step. In order to avoid duplicate entity
+    // keys, we need to look for the user before creating anything.
+    userEntity = await jobState.findEntity(parsedIdentifier);
+    if (!userEntity) {
+      userEntity = await jobState.addEntity(
+        createIamUserEntity({
+          type: parsedMemberType,
+          identifier: parsedIdentifier,
+          uniqueid: parsedMember.uniqueid,
+          deleted: parsedMember.deleted,
+        }),
+      );
+    }
   }
 
   return userEntity;

--- a/src/steps/resource-manager/index.ts
+++ b/src/steps/resource-manager/index.ts
@@ -44,33 +44,29 @@ async function maybeFindOrCreateIamUserEntity({
     return null;
   }
 
-  let userEntity: Entity | null;
-
+  // We always want to find or create relationships to user entities. Since
+  // the same user can have multiple roles, there is a possibility that a
+  // user is created earlier in this step. In order to avoid duplicate entity
+  // keys, we need to look for the user before creating anything.
+  const userEntity = await jobState.findEntity(parsedIdentifier);
   if (parsedMember.type === 'serviceAccount') {
     // We already created service accounts in another step. If this service
     // account does not exist, it's possible that it was created in between
     // steps. The caller handles the case that not entity is returned, so we
     // will just ignore it.
-    userEntity = await jobState.findEntity(parsedIdentifier);
-  } else {
-    // We always want to find or create relationships to user entities. Since
-    // the same user can have multiple roles, there is a possibility that a
-    // user is created earlier in this step. In order to avoid duplicate entity
-    // keys, we need to look for the user before creating anything.
-    userEntity = await jobState.findEntity(parsedIdentifier);
-    if (!userEntity) {
-      userEntity = await jobState.addEntity(
-        createIamUserEntity({
-          type: parsedMemberType,
-          identifier: parsedIdentifier,
-          uniqueid: parsedMember.uniqueid,
-          deleted: parsedMember.deleted,
-        }),
-      );
-    }
+    return userEntity;
   }
-
-  return userEntity;
+  return (
+    userEntity ||
+    (await jobState.addEntity(
+      createIamUserEntity({
+        type: parsedMemberType,
+        identifier: parsedIdentifier,
+        uniqueid: parsedMember.uniqueid,
+        deleted: parsedMember.deleted,
+      }),
+    ))
+  );
 }
 
 async function findOrCreateIamRoleEntity({


### PR DESCRIPTION
The previous code always created a `User` entity in this step, not taking into account that the previous `PolicyMemberBinding`s could target the same user. Fixed by always checking if a user exists before creating the relationship.

Once I get an approval I'll bump the version (minor to `3.1.0`, instead of patch to `3.0.1`, because there are other unreleased changes noted in the `CHANGELOG`).