### PR TITLE
Improve experience of '403: Caller does not have permission' error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,19 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 0.10.0 - 2020-12-11
+
+### Changed
+
 - Improve job log messaging when `/v1/projects/{projectId}` request responds
   with 403:FORBIDDEN. Previously, the job log simply stated "The caller does not
   have permission".
+
+### Added
+
 - Add `roles/iam.roleViewer` as a required role in developer documentation. This
   role includes the `resourcemanager.projects.get` permission, which is required
   to access the `/v1/projects/{projectId}` endpoint.
-
-## 0.10.0 - 2020-11-11
-
 - Improve JupiterOne Google Cloud organization script to walk all folders in an
   organization.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Improve job log messaging when `/v1/projects/{projectId}` request responds
+  with 403:FORBIDDEN. Previously, the job log simply stated "The caller does not
+  have permission".
+- Add `roles/iam.roleViewer` as a required role in developer documentation. This
+  role includes the `resourcemanager.projects.get` permission, which is required
+  to access the `/v1/projects/{projectId}` endpoint.
+
 ## 0.10.0 - 2020-11-11
 
 - Improve JupiterOne Google Cloud organization script to walk all folders in an

--- a/docs/development.md
+++ b/docs/development.md
@@ -132,9 +132,11 @@ gcloud iam service-accounts create j1-gc-integration-dev-sa \
 ### Bind IAM policy to integration service account
 
 We must assign the correct permissions to the newly created service account for
-the integration to be run. We recommend using the
-[`roles/iam.securityReviewer`](https://cloud.google.com/iam/docs/understanding-roles#iam.securityReviewer)
-role, which is managed by Google Cloud.
+the integration to be run. We recommend using the following roles managed by
+Google Cloud:
+
+- [`roles/iam.securityReviewer`](https://cloud.google.com/iam/docs/understanding-roles#iam.securityReviewer)
+- [`roles/iam.roleViewer`](https://cloud.google.com/iam/docs/understanding-roles#iam.roleViewer)
 
 To bind integration execution roles, run the
 [`gcloud iam add-iam-policy-binding`](https://cloud.google.com/sdk/gcloud/reference/iam/service-accounts/add-iam-policy-binding)
@@ -144,6 +146,10 @@ command:
 gcloud projects add-iam-policy-binding PROJECT_ID \
    --member serviceAccount:j1-gc-integration-dev-sa@PROJECT_ID.iam.gserviceaccount.com \
    --role "roles/iam.securityReviewer"
+
+gcloud projects add-iam-policy-binding PROJECT_ID \
+   --member serviceAccount:j1-gc-integration-dev-sa@PROJECT_ID.iam.gserviceaccount.com \
+   --role "roles/iam.roleViewer"
 ```
 
 NOTE: You must update the values above to match your service account details.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google-cloud",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A graph conversion tool for https://cloud.google.com/",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/steps/resource-manager/index.ts
+++ b/src/steps/resource-manager/index.ts
@@ -162,12 +162,12 @@ export async function fetchResourceManagerProject(
     if (err.code === 403) {
       logger.warn({ err }, message);
       logger.publishEvent({
-        name: 'GET_PROJECT_FORBIDDEN_ERROR',
+        name: 'get_project_forbidden_error',
         description: message,
       });
     } else {
       logger.publishErrorEvent({
-        name: 'GET_PROJECT_ERROR',
+        name: 'get_project_error',
         message,
         err,
       });

--- a/src/steps/resource-manager/index.ts
+++ b/src/steps/resource-manager/index.ts
@@ -161,17 +161,13 @@ export async function fetchResourceManagerProject(
       `${JSON.stringify({ code: err.code, message: err.message })}`;
     if (err.code === 403) {
       logger.warn({ err }, message);
-      logger.publishEvent({
-        name: 'get_project_forbidden_error',
-        description: message,
-      });
     } else {
-      logger.publishErrorEvent({
-        name: 'get_project_error',
-        message,
-        err,
-      });
+      logger.error({ err }, message);
     }
+    logger.publishEvent({
+      name: 'auth_error',
+      description: message,
+    });
   }
 
   const projectEntity = createProjectEntity(

--- a/src/steps/resource-manager/index.ts
+++ b/src/steps/resource-manager/index.ts
@@ -155,16 +155,19 @@ export async function fetchResourceManagerProject(
     // This step _always_ executes because it creates a root `Account` entity for the integration instance.
     // However, users can only fetch the project details if cloudresourcemanager API is enabled.
     const message =
-      'Could not fetch project from Cloud Resource Manager API. Ensure the API is enabled (see https://github.com/JupiterOne/graph-google-cloud/blob/master/docs/development.md#enabling-google-cloud-services)';
+      'Could not fetch project from Cloud Resource Manager API. Ensure the API is enabled and the service account has the ' +
+      '`resourcemanager.projects.get` permission (see ' +
+      'https://github.com/JupiterOne/graph-google-cloud/blob/master/docs/development.md#enabling-google-cloud-services) ' +
+      `${JSON.stringify({ code: err.code, message: err.message })}`;
     if (err.code === 403) {
       logger.warn({ err }, message);
       logger.publishEvent({
-        name: 'FETCH_PROJECT_ERROR',
-        description: err.message || `403: ${message}`,
+        name: 'GET_PROJECT_FORBIDDEN_ERROR',
+        description: message,
       });
     } else {
       logger.publishErrorEvent({
-        name: 'FETCH_PROJECT_ERROR',
+        name: 'GET_PROJECT_ERROR',
         message,
         err,
       });


### PR DESCRIPTION
Previously, if `err.message` existed and the error was a 403, we would _only_ display `Caller does not have permission` in the job log. Now, we will display the full remediation message:

`Could not fetch project from Cloud Resource Manager API. Ensure the API is enabled (see 'https://github.com/JupiterOne/graph-google-cloud/blob/master/docs/development.md#enabling-google-cloud-services) {code:403,message:'Caller does not have permission'}`

Related to #38 