### PR TITLE
Add custom role binding for the sa integration runner

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -8,6 +8,16 @@ resource "google_project_iam_custom_role" "ga_custom_role" {
   ]
 }
 
+resource "google_project_iam_custom_role" "extended_role" {
+  role_id     = "${var.project_id_number}extendedrole"
+  title       = "Security Reviewer Extender Role"
+  description = "A role that adds necessary permissions for the integration that aren't granted via Security Reviewer role"
+  permissions = [
+    "compute.projects.get",
+    "resourcemanager.projects.get"
+  ]
+}
+
 resource "google_project_iam_custom_role" "ga_custom_role_conditions" {
   role_id     = "${var.project_id_number}customroleconditions"
   title       = "GA custom role conditions"
@@ -21,6 +31,13 @@ resource "google_project_iam_binding" "ga_custom_role_binding" {
   role = google_project_iam_custom_role.ga_custom_role.id
   members = [
     "serviceAccount:${var.client_email}"
+  ]
+}
+
+resource "google_project_iam_binding" "extender_role_binding" {
+  role = google_project_iam_custom_role.extended_role.id
+  members = [
+    "serviceAccount:${var.integration_runner_service_account_client_email}"
   ]
 }
 

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -28,6 +28,11 @@ variable "region" {
   default = "us-central1"
 }
 
+variable "integration_runner_service_account_client_email" {
+  type    = string
+  default = ""
+}
+
 ###########################################
 # Toggle provisioning of resources below
 ###########################################


### PR DESCRIPTION
This PR does few things:
- It recognizes and ingests the `integration_runner_service_account_client_email` variable coming from the Terraform Cloud.
- It creates a new custom role that adds all the necessary permissions for the integration (that Security Reviewer role otherwise doesn't include by default). This allows us to keep track of what changes are necessary.
- It binds that custom role to the `integration_runner_service_account_client_email` which represents the service account used for running the integration.

PS. This was discussed with @austinkelleher yesterday.

CC @aiwilliams @ndowmon @mknoedel