### PR TITLE
Delete redis instance using Terraform

### DIFF
--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -44,5 +44,5 @@ variable "enable_google_monitoring_alert_policy_example" {
 
 variable "enable_redis_instance_example" {
   type = bool
-  default = true
+  default = false
 }


### PR DESCRIPTION
@austinkelleher Deletes the Redis instance using Terraform as we no longer need it to be present in Google Cloud.