### PR TITLE
Delete spanner instance using Terraform

### DIFF
--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -49,5 +49,5 @@ variable "enable_redis_instance_example" {
 
 variable "enable_spanner_example" {
   type = bool
-  default = true
+  default = false
 }


### PR DESCRIPTION
@austinkelleher Deletes the Spanner instance using Terraform as we no longer need it to be present in Google Cloud.