### PR TITLE
Fix #108 - Provide message instead of UNKNOWN when project is not a workspace

### DIFF
--- a/src/google-cloud/client.ts
+++ b/src/google-cloud/client.ts
@@ -127,6 +127,7 @@ function shouldKeepErrorMessage(error: any) {
     'billing is disabled',
     'requires billing to be enabled',
     'it is disabled',
+    'is not a workspace'
   ];
   return (
     error?.message?.match &&


### PR DESCRIPTION
Attempts to fix the _Monitoring Alert Policies step fails when a project is not assigned to a workspace_ #108 issue.

This is very _experimental_ because I wasn't able to modify my gcloud environment to run into this example where some project is not a workspace. Tried creating multiple projects and then merging their workspaces to get into a state where some project isn't a workspace (but is instead part of another workspace) and then to run integration using that project's credentials, but just didn't work for me for some reasons.

This change, unless I'm mistaken, should replace the UNKNOWN part and the error *should* look something similar to this:
`17:00:45.042Z ERROR Local: Step "Monitoring Alert Policies" failed to complete due to error. (errorCode="PROVIDER_API_ERROR", errorId="abe125be-2a14-42e6-9c27-9b023f218c1a", reason="projects/{this.projectId}' is not a workspace")`

Would be great if this can be tested and also let me know if you wanted something totally different and this isn't enough (even if it works). For what it's worth it doesn't seem like it's possible to check if the project is a workspace beforehand using API :thinking: 

Pinging: @aiwilliams @austinkelleher