### PR TITLE
Add readonly property to google_iam_role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to
 - New properties added to resources:
   - `google_cloud_api_service`
     - `hasIamPermissions`
+- `google_iam_role`
+  - `readonly`
 
 ## 0.23.1 - 2021-05-03
 

--- a/src/steps/app-engine/__snapshots__/index.test.ts.snap
+++ b/src/steps/app-engine/__snapshots__/index.test.ts.snap
@@ -900,6 +900,7 @@ Object {
       "etag": undefined,
       "name": "roles/owner",
       "permissions": undefined,
+      "readonly": true,
       "stage": undefined,
     },
     Object {

--- a/src/steps/iam/__snapshots__/converters.test.ts.snap
+++ b/src/steps/iam/__snapshots__/converters.test.ts.snap
@@ -34,6 +34,7 @@ Object {
     "cloudfunctions.functions.get",
     "cloudfunctions.functions.getIamPolicy",
   ],
+  "readonly": true,
   "stage": "GA",
 }
 `;
@@ -72,6 +73,7 @@ Object {
     "cloudfunctions.functions.get",
     "cloudfunctions.functions.getIamPolicy",
   ],
+  "readonly": true,
   "stage": "GA",
 }
 `;

--- a/src/steps/iam/__snapshots__/index.test.ts.snap
+++ b/src/steps/iam/__snapshots__/index.test.ts.snap
@@ -36,6 +36,7 @@ Object {
         "cloudfunctions.functions.get",
         "cloudfunctions.functions.getIamPolicy",
       ],
+      "readonly": true,
       "stage": "GA",
     },
     Object {
@@ -69,6 +70,7 @@ Object {
       "permissions": Array [
         "cloudfunctions.functions.list",
       ],
+      "readonly": true,
       "stage": "GA",
     },
     Object {
@@ -104,6 +106,7 @@ Object {
         "compute.projects.get",
         "resourcemanager.projects.get",
       ],
+      "readonly": true,
       "stage": "GA",
     },
   ],

--- a/src/steps/iam/converters.ts
+++ b/src/steps/iam/converters.ts
@@ -16,7 +16,7 @@ import {
   IAM_USER_ENTITY_CLASS,
   IAM_USER_ENTITY_TYPE,
 } from './constants';
-import { ParsedIamMemberType } from '../../utils/iam';
+import { isReadOnlyRole, ParsedIamMemberType } from '../../utils/iam';
 import { createGoogleCloudIntegrationEntity } from '../../utils/entity';
 
 export function createIamRoleEntity(
@@ -48,6 +48,7 @@ export function createIamRoleEntity(
         custom: custom === true,
         deleted: data.deleted === true,
         permissions: data.includedPermissions,
+        readonly: isReadOnlyRole(data),
         etag: data.etag,
       },
     },

--- a/src/steps/iam/index.test.ts
+++ b/src/steps/iam/index.test.ts
@@ -55,6 +55,7 @@ describe('#fetchIamRoles', () => {
             items: { type: 'string' },
           },
           etag: { type: 'string' },
+          readonly: { type: 'boolean' },
         },
       },
     });

--- a/src/steps/resource-manager/__snapshots__/index.test.ts.snap
+++ b/src/steps/resource-manager/__snapshots__/index.test.ts.snap
@@ -36,6 +36,7 @@ Object {
         "cloudfunctions.functions.get",
         "cloudfunctions.functions.getIamPolicy",
       ],
+      "readonly": true,
       "stage": "GA",
     },
     Object {
@@ -69,6 +70,7 @@ Object {
       "permissions": Array [
         "cloudfunctions.functions.list",
       ],
+      "readonly": true,
       "stage": "GA",
     },
     Object {
@@ -108,6 +110,7 @@ Object {
         "compute.projects.get",
         "resourcemanager.projects.get",
       ],
+      "readonly": true,
       "stage": "GA",
     },
     Object {
@@ -754,6 +757,7 @@ Object {
       "etag": undefined,
       "name": "roles/editor",
       "permissions": undefined,
+      "readonly": true,
       "stage": undefined,
     },
     Object {
@@ -779,6 +783,7 @@ Object {
       "etag": undefined,
       "name": "roles/iam.securityReviewer",
       "permissions": undefined,
+      "readonly": true,
       "stage": undefined,
     },
     Object {
@@ -804,6 +809,7 @@ Object {
       "etag": undefined,
       "name": "roles/owner",
       "permissions": undefined,
+      "readonly": true,
       "stage": undefined,
     },
     Object {
@@ -879,6 +885,7 @@ Object {
       "etag": undefined,
       "name": "roles/storage.admin",
       "permissions": undefined,
+      "readonly": true,
       "stage": undefined,
     },
   ],

--- a/src/utils/iam.ts
+++ b/src/utils/iam.ts
@@ -217,3 +217,40 @@ export function buildPermissionsByApiServiceMap(roles: iam_v1.Schema$Role[]) {
 
   return permissionsByServiceMap;
 }
+
+/**
+ * Determines whether a Google Cloud permission is read-only or not
+ *
+ * See: https://cloud.google.com/iam/docs/permissions-reference
+ *
+ * Examples:
+ *
+ * Input: binaryauthorization.attestors.update
+ * Output: false
+ *
+ * Input: binaryauthorization.continuousValidationConfig.get
+ * Output: true
+ */
+export function isReadOnlyPermission(permission: string): boolean {
+  const splitPermission = permission.split('.');
+  const action = splitPermission[splitPermission.length - 1];
+  return (
+    action === 'group' ||
+    action.startsWith('get') ||
+    action.startsWith('list') ||
+    action.startsWith('export') ||
+    action.startsWith('view') ||
+    action.startsWith('check') ||
+    action.startsWith('read')
+  );
+}
+
+export function isReadOnlyRole(role: iam_v1.Schema$Role): boolean {
+  for (const permission of role.includedPermissions || []) {
+    if (!isReadOnlyPermission(permission)) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
This is a bit of a clever method in order to answer the following questions without complex J1QL filtering:

> Which Google Cloud roles are read-only?

```
find google_iam_role with readonly=true
```

> Which Google Cloud roles have write access?

```
find google_iam_role with readonly=false
```