### PR TITLE
Fixes #171 - Suppress error when App Engine applications cannot be fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 0.32.0 - 2021-06-04
+
+### Added
+
+- Support for ingesting the following **new** entities
+
+  - Google Cloud
+    - `google_cloud_organization`
+
+### Fixed
+
+- [#171](https://github.com/JupiterOne/graph-google-cloud/issues/171) - Suppress
+  errors when App Engine application is not found
+
 ## 0.31.0 - 2021-06-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google-cloud",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "A graph conversion tool for https://cloud.google.com/",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/steps/app-engine/index.ts
+++ b/src/steps/app-engine/index.ts
@@ -58,9 +58,16 @@ async function withAppEngineErrorHandling<T>(
   try {
     return await fn();
   } catch (err) {
-    if (err._cause?.code === 404) {
+    if (
+      err._cause?.code === 404 ||
+      err.message.startsWith('Could not find Application')
+    ) {
       logger.info(
-        { err, projectId },
+        {
+          err,
+          projectId,
+          code: err._cause?.code,
+        },
         'Could not fetch app engine data for project',
       );
 

--- a/src/steps/app-engine/index.ts
+++ b/src/steps/app-engine/index.ts
@@ -66,7 +66,8 @@ async function withAppEngineErrorHandling<T>(
         {
           err,
           projectId,
-          code: err._cause?.code,
+          code: err.code,
+          causeCode: err._cause?.code,
         },
         'Could not fetch app engine data for project',
       );


### PR DESCRIPTION
This is kind of a hack. I added some additional logging and will clean it up when I know more. This should never cause the step to fail though.