### PR TITLE
Rename configureOrganizationAccounts integration config property to configureOrganizationProjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 0.34.1 - 2021-06-06
+
+### Fixed
+
+- Rename `configureOrganizationAccounts` integration config property to
+  `configureOrganizationProjects`
+
 ## 0.34.0 - 2021-06-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google-cloud",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "A graph conversion tool for https://cloud.google.com/",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -114,7 +114,7 @@ function makeStepStartStates(
 
 // Perhaps needs a better name?
 // Idea here is that we encapsulate/group all the steps that should be run
-// when configureOrganizationAccounts is set
+// when configureOrganizationProjects is set
 export function getOrganizationSteps() {
   return [
     // First of many, others will be VPC-related
@@ -138,7 +138,7 @@ export default async function getStepStartStates(
     serializedIntegrationConfig,
   ));
 
-  const organizationSteps = { disabled: !config.configureOrganizationAccounts };
+  const organizationSteps = { disabled: !config.configureOrganizationProjects };
 
   let enabledServiceNames: string[];
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -157,7 +157,7 @@ describe('#getStepStartStates success', () => {
   test('should return all enabled services', async () => {
     const context = createMockExecutionContext<IntegrationConfig>({
       // Unless we want to change what this test does, we need to modify the
-      // instanceConfig with configureOrganizationAccounts: true, else not
+      // instanceConfig with configureOrganizationProjects: true, else not
       // all steps will be enabled it'll be disabled
 
       // Temporary tweak to make this test pass since its recording has been updated from the new organization/v3
@@ -171,7 +171,7 @@ describe('#getStepStartStates success', () => {
           ...integrationConfig.serviceAccountKeyConfig,
           project_id: 'j1-gc-integration-dev-v3',
         },
-        configureOrganizationAccounts: true,
+        configureOrganizationProjects: true,
       },
     });
 
@@ -356,7 +356,7 @@ describe('#getStepStartStates success', () => {
     expect(stepStartStates).toEqual(expectedStepStartStates);
   });
 
-  test('configureOrganizationAccounts: true', async () => {
+  test('configureOrganizationProjects: true', async () => {
     const context = createMockExecutionContext<IntegrationConfig>({
       // Temporary tweak to make this test pass since its recording has been updated from the new organization/v3
       instanceConfig: {
@@ -369,7 +369,7 @@ describe('#getStepStartStates success', () => {
           ...integrationConfig.serviceAccountKeyConfig,
           project_id: 'j1-gc-integration-dev-v3',
         },
-        configureOrganizationAccounts: true,
+        configureOrganizationProjects: true,
       },
     });
 
@@ -388,7 +388,7 @@ describe('#getStepStartStates success', () => {
     });
   });
 
-  test('configureOrganizationAccounts: false or undefined', async () => {
+  test('configureOrganizationProjects: false or undefined', async () => {
     const context = createMockExecutionContext<IntegrationConfig>({
       // Temporary tweak to make this test pass since its recording has been updated from the new organization/v3
       instanceConfig: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> =
       organizationId: {
         type: 'string',
       },
-      configureOrganizationAccounts: {
+      configureOrganizationProjects: {
         type: 'boolean',
         mask: false,
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,6 @@ export type IntegrationStepContext =
 
 export interface SerializedIntegrationConfig extends IntegrationInstanceConfig {
   serviceAccountKeyFile: string;
-  configureOrganizationProjects?: boolean;
   organizationId?: string;
   /**
    * The project ID that this integration should target for ingestion. This
@@ -22,7 +21,7 @@ export interface SerializedIntegrationConfig extends IntegrationInstanceConfig {
    * target.
    */
   projectId?: string;
-  configureOrganizationAccounts?: boolean;
+  configureOrganizationProjects?: boolean;
 }
 
 export interface IntegrationConfig extends SerializedIntegrationConfig {


### PR DESCRIPTION
`configureOrganizationProjects` is the actual config property name.

FYI @eXtremeX