### PR TITLE
Update BigQuery documentation to use more appropriate role

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -140,7 +140,7 @@ Google Cloud:
 
 - [`roles/iam.securityReviewer`](https://cloud.google.com/iam/docs/understanding-roles#iam.securityReviewer)
 - [`roles/iam.roleViewer`](https://cloud.google.com/iam/docs/understanding-roles#iam.roleViewer)
-- [`roles/bigquery.dataViewer`](https://cloud.google.com/iam/docs/understanding-roles#bigquery.dataViewer)
+- [`roles/bigquery.metadataViewer`](https://cloud.google.com/bigquery/docs/access-control#bigquery.metadataViewer)
 
 Some additional data may be optionally ingested by the JupiterOne Google Cloud
 integration by configuring a custom role with the following permissions:


### PR DESCRIPTION
`roles/bigquery.dataViewer` is a bit over provisioned. J1 currently only needs access to these APIs:

```
bigquery.tables.list
bigquery.tables.getIamPolicy
bigquery.datasets.list
bigquery.datasets.get
bigquery.models.list
bigquery.models.get
```