### PR TITLE
Upgrade firewall relationships keys (duplicate key issue)

### DIFF
--- a/src/steps/compute/__snapshots__/converters.test.ts.snap
+++ b/src/steps/compute/__snapshots__/converters.test.ts.snap
@@ -1113,7 +1113,7 @@ Object {
 exports[`#createFirewallRuleMappedRelationship should convert to mapped relationship 1`] = `
 Object {
   "_class": "ALLOWS",
-  "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/public-compute-app-fw-allow-https:tcp:0.0.0.0/0:443",
+  "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/public-compute-app-fw-allow-https:0:tcp:0:0.0.0.0/0:443",
   "_mapping": Object {
     "relationshipDirection": "REVERSE",
     "skipTargetCreation": true,

--- a/src/steps/compute/__snapshots__/index.test.ts.snap
+++ b/src/steps/compute/__snapshots__/index.test.ts.snap
@@ -5848,7 +5848,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/default-allow-icmp:icmp:0.0.0.0/0:*",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/default-allow-icmp:0:icmp:0:0.0.0.0/0:*",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -5898,7 +5898,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/default-allow-internal:tcp:10.128.0.0/9:*",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/default-allow-internal:0:tcp:0:10.128.0.0/9:*",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -5926,7 +5926,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/default-allow-internal:udp:10.128.0.0/9:*",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/default-allow-internal:1:udp:0:10.128.0.0/9:*",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -5954,7 +5954,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/default-allow-internal:icmp:10.128.0.0/9:*",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/default-allow-internal:2:icmp:0:10.128.0.0/9:*",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -5998,7 +5998,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/default-allow-rdp:tcp:0.0.0.0/0:3389",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/default-allow-rdp:0:tcp:0:0.0.0.0/0:3389",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6048,7 +6048,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/default-allow-ssh:tcp:0.0.0.0/0:22",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/default-allow-ssh:0:tcp:0:0.0.0.0/0:22",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6098,7 +6098,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-all:tcp:10.16.0.0/14:*",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-all:0:tcp:0:10.16.0.0/14:*",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6126,7 +6126,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-all:udp:10.16.0.0/14:*",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-all:1:udp:0:10.16.0.0/14:*",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6154,7 +6154,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-all:icmp:10.16.0.0/14:*",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-all:2:icmp:0:10.16.0.0/14:*",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6182,7 +6182,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-all:esp:10.16.0.0/14:*",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-all:3:esp:0:10.16.0.0/14:*",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6210,7 +6210,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-all:ah:10.16.0.0/14:*",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-all:4:ah:0:10.16.0.0/14:*",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6238,7 +6238,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-all:sctp:10.16.0.0/14:*",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-all:5:sctp:0:10.16.0.0/14:*",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6282,7 +6282,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-ssh:tcp:34.69.207.11/32:22",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-ssh:0:tcp:0:34.69.207.11/32:22",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6309,7 +6309,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-ssh:tcp:34.70.193.119/32:22",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-ssh:0:tcp:0:34.70.193.119/32:22",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6336,7 +6336,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-ssh:tcp:35.232.163.225/32:22",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-ssh:0:tcp:0:35.232.163.225/32:22",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6379,7 +6379,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-vms:icmp:10.128.0.0/9:*",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-vms:0:icmp:0:10.128.0.0/9:*",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6407,7 +6407,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-vms:tcp:10.128.0.0/9:1-65535",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-vms:1:tcp:0:10.128.0.0/9:1-65535",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6435,7 +6435,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-vms:udp:10.128.0.0/9:1-65535",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/gke-j1-gc-integration-dev-gke-cluster-8bbab011-vms:2:udp:0:10.128.0.0/9:1-65535",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6479,7 +6479,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/public-compute-app-fw-allow-http:tcp:0.0.0.0/0:80",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/public-compute-app-fw-allow-http:0:tcp:0:0.0.0.0/0:80",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6529,7 +6529,7 @@ Object {
     },
     Object {
       "_class": "ALLOWS",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/public-compute-app-fw-allow-https:tcp:0.0.0.0/0:443",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/public-compute-app-fw-allow-https:0:tcp:0:0.0.0.0/0:443",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,
@@ -6579,7 +6579,7 @@ Object {
     },
     Object {
       "_class": "DENIES",
-      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/public-compute-app-fw-deny-ssh:tcp:0.0.0.0/0:22",
+      "_key": "https://www.googleapis.com/compute/v1/projects/j1-gc-integration-dev-v2/global/firewalls/public-compute-app-fw-deny-ssh:0:tcp:0:0.0.0.0/0:22",
       "_mapping": Object {
         "relationshipDirection": "REVERSE",
         "skipTargetCreation": true,

--- a/src/steps/compute/converters.test.ts
+++ b/src/steps/compute/converters.test.ts
@@ -238,6 +238,8 @@ describe('#createFirewallRuleMappedRelationship', () => {
           portRange: '443',
           fromPort: 443,
           toPort: 443,
+          ruleIndex: 0,
+          protocolIndex: 0,
         },
       }),
     ).toMatchSnapshot();

--- a/src/steps/compute/converters.ts
+++ b/src/steps/compute/converters.ts
@@ -749,13 +749,17 @@ export function toFirewallRuleRelationshipKey({
   portRange,
   ipRange,
   protocol,
+  ruleIndex,
+  protocolIndex,
 }: {
   firewallEntity: Entity;
   portRange: string;
   ipRange: string;
   protocol: string;
+  ruleIndex: number;
+  protocolIndex: number;
 }) {
-  return `${firewallEntity._key}:${protocol}:${ipRange}:${portRange}`;
+  return `${firewallEntity._key}:${ruleIndex}:${protocol}:${protocolIndex}:${ipRange}:${portRange}`;
 }
 
 export function createFirewallRuleMappedRelationship({
@@ -773,6 +777,8 @@ export function createFirewallRuleMappedRelationship({
   firewallEntity: Entity;
   properties: FirewallRuleRelationshipTargetProperties;
 }) {
+  const { ruleIndex, protocolIndex, ...propertiesWithoutIndices } = properties;
+
   return createMappedRelationship({
     _class,
     _mapping: {
@@ -789,8 +795,10 @@ export function createFirewallRuleMappedRelationship({
         ipRange: properties.ipRange,
         portRange: properties.portRange,
         protocol: properties.ipProtocol,
+        ruleIndex,
+        protocolIndex,
       }),
-      ...properties,
+      ...propertiesWithoutIndices,
     },
   });
 }

--- a/src/steps/compute/index.ts
+++ b/src/steps/compute/index.ts
@@ -724,8 +724,9 @@ export async function processFirewallRuleLists({
   const ipRanges = getFirewallIpRanges(firewall);
   const relationshipDirection = getFirewallRelationshipDirection(firewall);
 
-  for (const rule of firewall.allowed || []) {
+  for (const [ruleIndex, rule] of (firewall.allowed || []).entries()) {
     await processFirewallRuleRelationshipTargets({
+      ruleIndex,
       rule,
       ipRanges,
       callback: async (processedRuleTarget) => {
@@ -741,8 +742,9 @@ export async function processFirewallRuleLists({
     });
   }
 
-  for (const rule of firewall.denied || []) {
+  for (const [ruleIndex, rule] of (firewall.denied || []).entries()) {
     await processFirewallRuleRelationshipTargets({
+      ruleIndex,
       rule,
       ipRanges,
       callback: async (processedRuleTarget) => {

--- a/src/utils/firewall.test.ts
+++ b/src/utils/firewall.test.ts
@@ -172,6 +172,7 @@ describe('#processFirewallRuleRelationshipTargets', () => {
     };
 
     await processFirewallRuleRelationshipTargets({
+      ruleIndex: 0,
       rule,
       ipRanges: ['0.0.0.0/0'],
       callback: cb,
@@ -188,6 +189,8 @@ describe('#processFirewallRuleRelationshipTargets', () => {
         ipRange: '0.0.0.0/0',
         protocol: 'tcp',
         ipProtocol: 'tcp',
+        ruleIndex: 0,
+        protocolIndex: 0,
       },
     });
 
@@ -201,6 +204,8 @@ describe('#processFirewallRuleRelationshipTargets', () => {
         ipRange: '0.0.0.0/0',
         protocol: 'tcp',
         ipProtocol: 'tcp',
+        ruleIndex: 0,
+        protocolIndex: 1,
       },
     });
   });

--- a/src/utils/firewall.ts
+++ b/src/utils/firewall.ts
@@ -87,6 +87,8 @@ export interface FirewallRuleRelationshipTargetProperties
   ipRange: string;
   protocol: string;
   ipProtocol: string;
+  ruleIndex: number;
+  protocolIndex: number;
 }
 
 export interface FirewallRuleRelationshipTarget {
@@ -96,10 +98,12 @@ export interface FirewallRuleRelationshipTarget {
 }
 
 export async function processFirewallRuleRelationshipTargets({
+  ruleIndex,
   rule,
   ipRanges,
   callback,
 }: {
+  ruleIndex: number;
   rule: ComputeFirewallRule;
   ipRanges: string[];
   callback: (r: FirewallRuleRelationshipTarget) => Promise<void>;
@@ -107,13 +111,18 @@ export async function processFirewallRuleRelationshipTargets({
   const processedRule = processFirewallRule(rule);
   const protocol = processedRule.protocol.toLowerCase();
 
-  for (const processedRulePortData of processedRule.ports) {
+  for (const [
+    protocolIndex,
+    processedRulePortData,
+  ] of processedRule.ports.entries()) {
     for (const ipRange of ipRanges) {
       const relationshipProperties: FirewallRuleRelationshipTargetProperties = {
         ...processedRulePortData,
         ipRange,
         protocol,
         ipProtocol: protocol,
+        ruleIndex,
+        protocolIndex,
       };
 
       if (isInternet(ipRange)) {


### PR DESCRIPTION
INT-1198 - Required using indicates in the key because rules can specify the same protocol + IP + port and the key wasn't unique enough before.

@austinkelleher 