### PR TITLE
Handle cache name case where project is not available

### DIFF
--- a/src/steps/resource-manager/index.ts
+++ b/src/steps/resource-manager/index.ts
@@ -363,6 +363,7 @@ export async function fetchResourceManagerProject(
   let project;
   try {
     project = await client.getProject();
+    await cacheProjectNameToId(jobState, project);
   } catch (err) {
     // This step _always_ executes because it creates a root `Account` entity for the integration instance.
     // However, users can only fetch the project details if cloudresourcemanager API is enabled.
@@ -383,7 +384,6 @@ export async function fetchResourceManagerProject(
   }
 
   const projectEntity = createProjectEntity(client.projectId, project);
-  await cacheProjectNameToId(jobState, project);
 
   await jobState.setData(PROJECT_ENTITY_TYPE, projectEntity);
   await jobState.addEntity(projectEntity);


### PR DESCRIPTION
INT-1200
The issue was the following: If the Cloud Resource Manager service was disabled, we wouldn't have gotten the project in the code (near this fix) and the `cacheProjectNameToId` wouldn't be able to work. We've moved it to inside the try-catch block so that it never executes if the service is disabled.

@austinkelleher 
