### PR TITLE
[DO NOT MERGE] INT-1561  - add private, publicRead or publicWrite on all resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to
 
 ### Added
 
+- Added support for ingesting the following **new** properties on direct and
+  mapped `google_iam_binding_allows_ANY_RESOURCE` relationships:
+
+  | Property                   | Type                                   | Description                                           |
+  | -------------------------- | -------------------------------------- | ----------------------------------------------------- |
+  | `accessLevel`              | 'private', 'publicRead', 'publicWrite' | The level public access on the contents of the bucket |
+  | `accessLevelIsConditional` | boolean                                | Whether there is a condition to the access or not     |
+  | `accessLevelCondition`     | string                                 | The condition for access at this access level         |
+
 - Added support for ingesting the following **new** properties on
   `google_storage_bucket`:
 

--- a/src/steps/cloud-asset/index.test.ts
+++ b/src/steps/cloud-asset/index.test.ts
@@ -39,6 +39,7 @@ import {
   CLOUD_STORAGE_BUCKET_ENTITY_TYPE,
 } from '../storage';
 import { CLOUD_FUNCTION_ENTITY_TYPE, fetchCloudFunctions } from '../functions';
+import { AccessData } from '../../utils/jobState';
 
 expect.extend({
   toHaveOnlyDirectRelationships(
@@ -266,6 +267,12 @@ describe('#fetchIamBindings', () => {
         encounteredTypes: context.jobState.encounteredTypes,
       }).toMatchSnapshot();
 
+      const accessLevels: AccessData['accessLevel'][] = [
+        'private',
+        'publicRead',
+        'publicWrite',
+      ];
+
       // Relationships
       const {
         google_iam_binding_uses_role,
@@ -325,8 +332,15 @@ describe('#fetchIamBindings', () => {
       ).toHaveOnlyMappedRelationships(
         'google_iam_binding_allows_cloud_project',
       );
+      google_iam_binding_allows_cloud_project.forEach((mappedRelationship) => {
+        expect(accessLevels).toContain(
+          (mappedRelationship as MappedRelationship)._mapping.targetEntity
+            .accessLevel,
+        );
+      });
 
       // Direct Relationships
+      // principal relationships
       expect(
         google_iam_binding_assigned_service_account,
       ).toHaveOnlyDirectRelationships(
@@ -337,14 +351,21 @@ describe('#fetchIamBindings', () => {
       ).toHaveOnlyDirectRelationships(
         'google_iam_service_account_assigned_role',
       );
+      // resource relationships
       expect(
         google_iam_binding_allows_cloud_organization,
       ).toHaveOnlyDirectRelationships(
         'google_iam_binding_allows_cloud_organization',
       );
+      google_iam_binding_allows_cloud_organization.forEach((relationship) => {
+        expect(accessLevels).toContain(relationship.accessLevel);
+      });
       expect(
         google_iam_binding_allows_cloud_folder,
       ).toHaveOnlyDirectRelationships('google_iam_binding_allows_cloud_folder');
+      google_iam_binding_allows_cloud_folder.forEach((relationship) => {
+        expect(accessLevels).toContain(relationship.accessLevel);
+      });
 
       // Entities
       const { google_iam_binding, google_iam_role } =


### PR DESCRIPTION
### WHAT WAS DONE
Analyze the organization level `google_iam_bindings` to determine the access level of every resource that has a binding.

![image](https://user-images.githubusercontent.com/25489482/129771969-71c8b434-1041-4c14-8c00-83d3ac51386b.png)

### POTENTIAL ISSUE WITH THIS SOLUTION
A `google_storage_bucket`'s accessLevel is dependent on other configuration factors only available on the bucket itself that override any IAM policy analysis. Because of this, if a mapped `google_iam_binding_allows_ANY_RESOURCE` relationship links up with a `google_storage_bucket` that does not have `uniformBucketLevelAccess` enabled that otherwise would be considered `private`, it's accessLevel would be updated from `subjectToObjectACLs` to `['subjectToObjectACLs', 'private']` thanks to the mapper. I determined this to be fine as we do not lose the `subjectToObjectACLs` value, though it might cause some confusion in the future.