### PR TITLE
INT-1561 - Add isPublic and isOpenToTheInternet to IAM bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- New properties added to resources:
+
+  | Entity                | Properties            |
+  | --------------------- | --------------------- |
+  | `google_iam_bindings` | `isReadOnly`          |
+  | `google_iam_bindings` | `isOpenToTheInternet` |
+
 ### Fixed
 
 - Managed `google_iam_roles` now have a `permissions` property, similar to

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -265,7 +265,7 @@ NOTE: ALL OF THE FOLLOWING DOCUMENTATION IS GENERATED USING THE
 "j1-integration document" COMMAND. DO NOT EDIT BY HAND! PLEASE SEE THE DEVELOPER
 DOCUMENTATION FOR USAGE INFORMATION:
 
-https://github.com/JupiterOne/sdk/blob/master/docs/integrations/development.md
+https://github.com/JupiterOne/sdk/blob/main/docs/integrations/development.md
 ********************************************************************************
 -->
 

--- a/src/steps/cloud-asset/__snapshots__/converters.test.ts.snap
+++ b/src/steps/cloud-asset/__snapshots__/converters.test.ts.snap
@@ -29,6 +29,8 @@ Object {
   "condition.title": "Test condition title",
   "createdOn": undefined,
   "displayName": "Role Binding for Resource: resource",
+  "isOpenToTheInternet": false,
+  "isReadOnly": true,
   "members": Array [
     "serviceAccount:j1-gc-integration-dev-sa-tf@j1-gc-integration-dev-v3.iam.gserviceaccount.com",
   ],

--- a/src/steps/cloud-asset/converters.test.ts
+++ b/src/steps/cloud-asset/converters.test.ts
@@ -1,26 +1,69 @@
 import { getMockRoleBinding } from '../../../test/mocks';
+import { PUBLIC_MEMBERS } from '../../utils/iam';
 import { buildIamBindingEntityKey, createIamBindingEntity } from './converters';
 
 describe('#createIamBindingEntity', () => {
+  const resource = 'resource';
+  const projectName = 'projects/123456789';
+  const projectId = 'project-id';
+  const binding = getMockRoleBinding();
+  const isReadOnly = true;
+
   test('should convert to entity', () => {
-    const resource = 'resource';
-    const projectName = 'projects/123456789';
-    const projectId = 'project-id';
-    const binding = getMockRoleBinding();
-
-    const _key = buildIamBindingEntityKey({
-      binding,
-      projectName,
-      resource,
-    });
-
     expect(
       createIamBindingEntity({
-        _key,
+        _key: buildIamBindingEntityKey({
+          binding,
+          projectName,
+          resource,
+        }),
         binding,
         projectId,
         resource,
+        isReadOnly,
       }),
     ).toMatchSnapshot();
+  });
+
+  PUBLIC_MEMBERS.forEach((member) => {
+    it(`Should set isOpenToTheInternet to "true" when a member is ${member}`, () => {
+      expect(
+        createIamBindingEntity({
+          _key: buildIamBindingEntityKey({
+            binding,
+            projectName,
+            resource,
+          }),
+          binding: {
+            ...binding,
+            members: [member],
+          },
+          projectId,
+          resource,
+          isReadOnly,
+        }).isOpenToTheInternet,
+      ).toBe(true);
+    });
+  });
+
+  ['gerald', 'nobody@here.com'].forEach((member) => {
+    it(`Should set isOpenToTheInternet to "false" when roles are assigned to specific users`, () => {
+      expect(
+        createIamBindingEntity({
+          _key: buildIamBindingEntityKey({
+            binding,
+            projectName,
+            resource,
+          }),
+          binding: {
+            ...binding,
+            members: [member],
+          },
+          projectId,
+          resource,
+          isReadOnly,
+        }).isOpenToTheInternet,
+      ).toBe(false);
+    });
   });
 });

--- a/src/steps/cloud-asset/converters.ts
+++ b/src/steps/cloud-asset/converters.ts
@@ -4,6 +4,7 @@ import { snakeCase } from 'lodash';
 import { hashArray } from '../../utils/crypto';
 
 import { createGoogleCloudIntegrationEntity } from '../../utils/entity';
+import { isMemberPublic } from '../../utils/iam';
 import { bindingEntities } from './constants';
 
 export interface BindingEntity extends Entity {
@@ -15,6 +16,8 @@ export interface BindingEntity extends Entity {
   'condition.description': string;
   'condition.expression': string;
   'condition.location': string;
+  isReadOnly: boolean;
+  isOpenToTheInternet: boolean;
 }
 
 export function buildIamBindingEntityKey({
@@ -44,11 +47,13 @@ export function createIamBindingEntity({
   projectId,
   binding,
   resource,
+  isReadOnly,
 }: {
   _key: string;
   projectId?: string;
   binding: cloudasset_v1.Schema$Binding;
   resource: string | undefined | null;
+  isReadOnly: boolean;
 }): BindingEntity {
   const namePrefix = 'Role Binding for Resource: ';
 
@@ -75,6 +80,8 @@ export function createIamBindingEntity({
         'condition.description': binding.condition?.description,
         'condition.expression': binding.condition?.expression,
         'condition.location': binding.condition?.location,
+        isReadOnly, // Are all the permissions associated with this binding read only permissions
+        isOpenToTheInternet: (binding.members ?? []).some(isMemberPublic), // Is there a member associated with this binding that is open to the internet
       },
     },
   }) as BindingEntity;

--- a/src/steps/cloud-asset/index.test.ts
+++ b/src/steps/cloud-asset/index.test.ts
@@ -38,6 +38,7 @@ import {
   CLOUD_STORAGE_BUCKET_ENTITY_TYPE,
 } from '../storage';
 import { CLOUD_FUNCTION_ENTITY_TYPE, fetchCloudFunctions } from '../functions';
+import { IAM_MANAGED_ROLES_DATA_JOB_STATE_KEY } from '../../utils/iam';
 
 expect.extend({
   toHaveOnlyDirectRelationships(
@@ -353,6 +354,7 @@ describe('#fetchIamBindings', () => {
       expect(google_iam_binding).toMatchGraphObjectSchema({
         _class: bindingEntities.BINDINGS._class,
         schema: {
+          additionalProperties: false,
           properties: {
             _type: { const: bindingEntities.BINDINGS._type },
             _rawData: {
@@ -362,15 +364,18 @@ describe('#fetchIamBindings', () => {
             resource: { type: 'string' },
             projectId: { type: 'string' },
             members: { type: 'array' },
+            role: { type: 'string' },
             'condition.title': { type: 'string' },
             'condition.description': { type: 'string' },
             'condition.expression': { type: 'string' },
+            'condition.location': { type: 'string' },
+            isReadOnly: { type: 'boolean' },
+            isOpenToTheInternet: { type: 'boolean' },
           },
         },
       });
 
-      expect(google_iam_role.length).toBeGreaterThan(0);
-      expect(google_iam_role).toMatchGraphObjectSchema({
+      const roleSchema = {
         _class: ['AccessRole'],
         schema: {
           additionalProperties: false,
@@ -389,6 +394,20 @@ describe('#fetchIamBindings', () => {
             readonly: { type: 'boolean' },
           },
         },
+      };
+      expect(google_iam_role.length).toBeGreaterThan(0);
+      expect(google_iam_role).toMatchGraphObjectSchema(roleSchema);
+      const { targets: roleMappedRelationships } = filterGraphObjects(
+        google_iam_binding_uses_role,
+        (r) => !!r._mapping,
+      ) as {
+        targets: ExplicitRelationship[];
+        rest: MappedRelationship[];
+      };
+      roleMappedRelationships.forEach((relationship) => {
+        expect(
+          (relationship as unknown as MappedRelationship)._mapping.targetEntity,
+        ).toMatchGraphObjectSchema(roleSchema);
       });
 
       // Ensure there are no mapped relationships to google_iam_roles that we are also ingesting
@@ -472,6 +491,10 @@ describe('#fetchIamBindings', () => {
 
         const context = createMockContext();
 
+        await context.jobState.setData(
+          IAM_MANAGED_ROLES_DATA_JOB_STATE_KEY,
+          {},
+        );
         await fetchIamBindings(context);
         await createBindingToAnyResourceRelationships(context);
 

--- a/src/utils/iam.ts
+++ b/src/utils/iam.ts
@@ -172,8 +172,9 @@ export function parseIamMember(member: string): ParsedIamMember {
  * - https://cloud.google.com/iam/docs/overview#allusers
  */
 export function isMemberPublic(member: string) {
-  return member === 'allUsers' || member === 'allAuthenticatedUsers';
+  return PUBLIC_MEMBERS.includes(member);
 }
+export const PUBLIC_MEMBERS = ['allUsers', 'allAuthenticatedUsers'];
 
 export async function getIamManagedRoleData(
   jobState: JobState,

--- a/src/utils/iamBindings/getTypeAndKeyFromResourceIdentifier.ts
+++ b/src/utils/iamBindings/getTypeAndKeyFromResourceIdentifier.ts
@@ -26,10 +26,14 @@ export interface TypeAndKey {
  *   returns - j1-gc-integration-dev-v3:natality
  */
 export async function getTypeAndKeyFromResourceIdentifier(
-  googleResourceIdentifier: string,
+  googleResourceIdentifier: string | undefined,
   context: StepExecutionContext,
 ): Promise<TypeAndKey> {
   const response: TypeAndKey = { metadata: {} };
+
+  if (!googleResourceIdentifier) {
+    return response;
+  }
 
   const googleResourceKind = findResourceKindFromCloudResourceIdentifier(
     googleResourceIdentifier,


### PR DESCRIPTION
### Added

- New properties added to resources:

  | Entity                | Properties            |
  | --------------------- | --------------------- |
  | `google_iam_bindings` | `isReadOnly`          |
  | `google_iam_bindings` | `isOpenToTheInternet` |

### Notes

#### Why Put Access Info on the Binding instead of the Resource?

Per [@ndowmon's suggestion in the previous INT-1561 PR](https://github.com/JupiterOne/graph-google-cloud/pull/293/files#r691460798), instead of allowing users to find the access level of various resources via querying that resource directly. Example:

```
FIND
  google_storage_bucket WITH accessLevel != 'private'
```

We can instead put the access information on the IAM binding and have users do a traversal query. Example:

```
FIND 
  google_storage_bucket 
  THAT ALLOWS google_iam_binding WITH accessLevel != 'private'
```

From the users perspective, this is slightly worse as they are expected to know the data structure of Role Bindings to Resources in order to form the query. However, from the ingestion perspective, this is far easier because we do not need to enhance entities with information, which our sdk does not support yet (See [sdk issue #532](https://github.com/JupiterOne/sdk/issues/532)).

If we needed to support the first query today, we would need to restructure the graph project in such a way where all access information is available at the time of creating entities, which I did in these 2 PRs ([INT-1142](https://github.com/JupiterOne/graph-google-cloud/pull/292/files#diff-575c3f04741892b0dd274bf9163166e8b560b5febde394fbb61344d572b69ac3), [INT-1561](https://github.com/JupiterOne/graph-google-cloud/pull/293/files)). Unfortunately, doing so makes this project significantly more difficult to work with in the future. Take a look for yourself, it's a bit hard to follow.

#### Why use `isReadOnly` and `isOpenToTheInternet` instead of an `accessLevel` of 'private', 'publicRead 'and 'publicWrite' values?
It felt to me that it would more clear to users making queries to put things into booleans instead of needing to have the user guess what the possible enum values of an entity property could be. How would a user know that the available accessLevels are `private` | `publicRead` | `publicWrite`? From what I can tell, the only ways would be we tell them or they look at the code. This problem goes away when you use boolean properties because each property is returned in J1QL queries.  My guess is that people can guess the available values of `isReadOnly` and `isOpenToTheInternet` quite easily. Of course another way to solve this problem would be to provide type docs for each entity, but we do not have those yet.


