### PR TITLE
INT-1697 - Add past changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added support for ingesting the following **new** resources:
+
+  | Service        | Resource / Entity                                                                                                                       |
+  | -------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+  | Dataproc       | `google_dataproc_cluster`                                                                                                               |
+  | Cloud Billing  | `google_billing_account`                                                                                                                |
+  | N/A            | `google_billing_budget`                                                                                                                 |
+  | Cloud Bigtable | `google_bigtable_app_profile`, `google_bigtable_backup`, `google_bigtable_cluster`, `google_bigtable_instance`, `google_bigtable_table` |
+
+- Added support for ingesting the following **new** relationships:
+
+  | Source                     | class  | Target                        |
+  | -------------------------- | ------ | ----------------------------- |
+  | `google_dataproc_cluster`  | `USES` | `google_kms_crypto_key`       |
+  | `google_dataproc_cluster`  | `USES` | `google_compute_image`        |
+  | `google_dataproc_cluster`  | `USES` | `google_storage_bucket`       |
+  | `google_billing_account`   | `HAS`  | `google_billing_budget`       |
+  | `google_cloud_project`     | `USES` | `google_billing_budget`       |
+  | `google_bigtable_cluster`  | `HAS`  | `google_bigtable_backup`      |
+  | `google_bigtable_cluster`  | `USES` | `google_kms_crypto_key`       |
+  | `google_bigtable_instance` | `HAS`  | `google_bigtable_app_profile` |
+  | `google_bigtable_instance` | `HAS`  | `google_bigtable_cluster`     |
+  | `google_bigtable_instance` | `HAS`  | `google_bigtable_table`       |
+  | `google_bigtable_table`    | `HAS`  | `google_bigtable_backup`      |
+
 ### Changed
 
 - Relationships from `google_cloud_organization`s and `google_cloud_folder`s to
@@ -22,6 +49,11 @@ and this project adheres to
   | `google_iam_binding` | **ASSIGNED** | `google_user`                |
   | `google_iam_binding` | **ASSIGNED** | `google_domain`              |
   | `google_user`        | **CREATED**  | `google_app_engine_version`  |
+
+- Separate the step to build `google_bigquery_dataset_uses_kms_crypto_key`
+  relationship
+- Modified `google_bigquery_dataset` step to be independent from
+  `google_kms_crypto_key` step
 
 ## 0.48.0 - 2021-08-27
 


### PR DESCRIPTION
This is a very simple PR: we haven't been updating changelogs in our previous PRs that got merged, this PR updates the changelog with all of those changes.

PRs changes contained within this PR are the following:
- INT-1208 - Ingest Dataproc clusters
- INT-1552 - Add Dataproc Cluster Image relationships
- INT-1237 & INT-1239 - Add Cloud Billing resources and Billing Budget
- INT-1553 - Add Dataproc Cluster Storage relationships
- INT-1236 - Add BigTable resources
- INT-1547 - Add a separate step to build relationship from BigQuery dataset to KMS

Pinging @aiwilliams @austinkelleher @ndowmon @mknoedel