### PR TITLE
INTS-23: Fix missing Internet --ALLOWS--> Firewall relationship

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist/
 tsconfig.tsbuildinfo
 coverage/
 main.remote.tf
+.DS_Store
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `Internet` **ALLOWS** `google_compute_firewall` relationship for
+  `0.0.0.0/0`/`::/0` source CIDR blocks restored by adding `_type` to the target
+  filter keys.
+
 ## 0.50.0 - 2021-09-15
 
 ### Added

--- a/docs/development.md
+++ b/docs/development.md
@@ -166,8 +166,8 @@ gcloud projects add-iam-policy-binding my-proj-id-123 \
 
 ### Generate a service account key
 
-A service account key will be used to to execute the integration. You can
-generate a service account key using the
+A service account key will be used to execute the integration. You can generate
+a service account key using the
 [`gcloud iam service-accounts keys create`](https://cloud.google.com/sdk/gcloud/reference/iam/service-accounts/keys/create)
 command:
 
@@ -204,7 +204,7 @@ PROJECT_ID="my-j1-proj"
 **Required** credentials for the JupiterOne integration to authenticate. The key
 file should be a flattened JSON string.
 
-The following is an example of an unflatted service account key file:
+The following is an example of an unflattened service account key file:
 
 ```json
 {

--- a/src/steps/compute/__snapshots__/index.test.ts.snap
+++ b/src/steps/compute/__snapshots__/index.test.ts.snap
@@ -8076,6 +8076,7 @@ Object {
         },
         "targetFilterKeys": Array [
           Array [
+            "_type",
             "_key",
           ],
         ],
@@ -8226,6 +8227,7 @@ Object {
         },
         "targetFilterKeys": Array [
           Array [
+            "_type",
             "_key",
           ],
         ],
@@ -8276,6 +8278,7 @@ Object {
         },
         "targetFilterKeys": Array [
           Array [
+            "_type",
             "_key",
           ],
         ],
@@ -8707,6 +8710,7 @@ Object {
         },
         "targetFilterKeys": Array [
           Array [
+            "_type",
             "_key",
           ],
         ],
@@ -8757,6 +8761,7 @@ Object {
         },
         "targetFilterKeys": Array [
           Array [
+            "_type",
             "_key",
           ],
         ],
@@ -8807,6 +8812,7 @@ Object {
         },
         "targetFilterKeys": Array [
           Array [
+            "_type",
             "_key",
           ],
         ],

--- a/src/utils/firewall.test.ts
+++ b/src/utils/firewall.test.ts
@@ -180,7 +180,7 @@ describe('#processFirewallRuleRelationshipTargets', () => {
 
     expect(cb).toHaveBeenCalledTimes(2);
     expect(cb).toHaveBeenNthCalledWith(1, {
-      targetFilterKeys: [['_key']],
+      targetFilterKeys: [['_type', '_key']],
       targetEntity: INTERNET,
       properties: {
         fromPort: 123,
@@ -195,7 +195,7 @@ describe('#processFirewallRuleRelationshipTargets', () => {
     });
 
     expect(cb).toHaveBeenNthCalledWith(2, {
-      targetFilterKeys: [['_key']],
+      targetFilterKeys: [['_type', '_key']],
       targetEntity: INTERNET,
       properties: {
         fromPort: 789,

--- a/src/utils/firewall.ts
+++ b/src/utils/firewall.ts
@@ -127,7 +127,7 @@ export async function processFirewallRuleRelationshipTargets({
 
       if (isInternet(ipRange)) {
         await callback({
-          targetFilterKeys: [['_key']],
+          targetFilterKeys: [['_type', '_key']],
           targetEntity: INTERNET,
           properties: relationshipProperties,
         });


### PR DESCRIPTION
Fixes missing internet allows firewall relationship from appearing in the graph on entities with `ingress: true`  + and an IP range of `0.0.0.0/0` by: setting `targetFilterKeys` to use both `_key` *and* `_type` (see existing `isInternet` usage for more info).

I'm trying to come up with a better explanation of why this worked so if anyone would like to enlighten me, please feel free to discuss more.

**Steps to Reproduce**
1. Create a new firewall entity that has not been used before (`gcloud compute firewall-rules create some-new-name --allow=tcp:XXXX --source-ranges="0.0.0.0/0" --description="Allow incoming traffic" --direction=INGRESS`)
2. Run your custom integration from the  `main` branch (`yarn run -i <id> -d`)
3. Observe the firewall has no internet allows connection. You may want to wait a few minutes to verify all sync tasks have completed.
4. Feel free to create another new firewall entity if desired (optional)
5. Deploy changes from this branch with the fix
6. Observe that internet connection is set correctly (the synchronization may take about 5 minutes to finish)

If you deploy back to main without this fix (maybe you want to test this again), you'll want to use a new firewall name that will have new relationship keys as the old relationship keys added in the fix may not get deleted automatically (i.e., if the integration is not tagged).