### PR TITLE
Prevent unable to find project id error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed unnecessary "UNABLE_TO_FIND_PROJECT_ID" error.
+
 ## 0.51.4 - 2021-09-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "format": "prettier --write '**/*.{ts,js,json,css,md,yml}'",
     "type-check": "tsc",
     "test:env": "LOAD_ENV=1 yarn test",
-    "test": "jest && yarn validate:questions:dry",
+    "test": "yarn validate:questions:dry && yarn jest",
     "test:ci": "yarn validate:questions && yarn lint && yarn type-check",
     "build": "./build.sh",
     "prepush": "yarn lint && yarn type-check && jest --changedSince main",

--- a/src/steps/cloud-asset/__snapshots__/converters.test.ts.snap
+++ b/src/steps/cloud-asset/__snapshots__/converters.test.ts.snap
@@ -34,6 +34,7 @@ Object {
   ],
   "name": "role_binding_for_resourceresource",
   "projectId": "project-id",
+  "projectName": undefined,
   "readonly": true,
   "resource": "resource",
   "role": "projects/j1-gc-integration-dev-v3/roles/167984947943customroleconditions",

--- a/src/steps/cloud-asset/converters.ts
+++ b/src/steps/cloud-asset/converters.ts
@@ -43,12 +43,14 @@ export function buildIamBindingEntityKey({
 export function createIamBindingEntity({
   _key,
   projectId,
+  projectName,
   binding,
   resource,
   isReadOnly,
 }: {
   _key: string;
   projectId?: string;
+  projectName?: string;
   binding: cloudasset_v1.Schema$Binding;
   resource: string | undefined | null;
   isReadOnly: boolean;
@@ -74,6 +76,7 @@ export function createIamBindingEntity({
         role: binding.role,
         members: binding.members,
         projectId,
+        projectName,
         'condition.title': binding.condition?.title,
         'condition.description': binding.condition?.description,
         'condition.expression': binding.condition?.expression,

--- a/src/steps/cloud-asset/index.test.ts
+++ b/src/steps/cloud-asset/index.test.ts
@@ -363,6 +363,7 @@ describe('#fetchIamBindings', () => {
             },
             resource: { type: 'string' },
             projectId: { type: 'string' },
+            projectName: { type: 'string' },
             members: { type: 'array' },
             role: { type: 'string' },
             'condition.title': { type: 'string' },


### PR DESCRIPTION
Not every Google Cloud organization structure will have access to the projectId in the jobState, so instead of erroring, we just store the projectName instead.