### PR TITLE
INT-1303 - Only map on _key when making any resource relationships with SQL instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Create target entities when making mapped `google_iam_binding_allows_resource`
+  and `google_cloud_api_service_has_resource` relationships.
+
+### Fixed
+
+- When making mapped `google_iam_binding_allows_resource` and
+  `google_cloud_api_service_has_resource` relationships to
+  `google_sql_postgres_instance`, `google_sql_sql_server_instance`, and
+  `google_sql_mysql_instance`. Only map on the `_key` property and not the
+  `_type`.
+
 ## 2.0.0 - 2021-10-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,6 @@ and this project adheres to
 
 ## [Unreleased]
 
-### Changed
-
-- Create target entities when making mapped `google_iam_binding_allows_resource`
-  and `google_cloud_api_service_has_resource` relationships.
-
 ### Fixed
 
 - When making mapped `google_iam_binding_allows_resource` and

--- a/src/steps/cloud-asset/constants.ts
+++ b/src/steps/cloud-asset/constants.ts
@@ -3,7 +3,6 @@ import {
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import { ANY_RESOURCE } from '../../constants';
-import { MULTIPLE_J1_TYPES_FOR_RESOURCE_KIND } from '../../utils/iamBindings/resourceKindToTypeMap';
 import { J1_TYPE_TO_KEY_GENERATOR_MAP } from '../../utils/iamBindings/typeToKeyGeneratorMap';
 import {
   ALL_AUTHENTICATED_USERS_TYPE,
@@ -15,11 +14,6 @@ import {
   IAM_SERVICE_ACCOUNT_ENTITY_TYPE,
 } from '../iam';
 import { API_SERVICE_ENTITY_TYPE } from '../service-usage';
-import {
-  SQL_ADMIN_MYSQL_INSTANCE_ENTITY_TYPE,
-  SQL_ADMIN_POSTGRES_INSTANCE_ENTITY_TYPE,
-  SQL_ADMIN_SQL_SERVER_INSTANCE_ENTITY_TYPE,
-} from '../sql-admin';
 
 export const STEP_IAM_BINDINGS = 'fetch-iam-bindings';
 export const STEP_CREATE_BASIC_ROLES = 'create-basic-roles';
@@ -68,13 +62,7 @@ export const BINDING_ASSIGNED_PRINCIPAL_RELATIONSHIPS = IAM_PRINCIPAL_TYPES.map(
   },
 );
 
-const bindingResourceTargetTypes = Object.keys(J1_TYPE_TO_KEY_GENERATOR_MAP)
-  .filter((type) => type != MULTIPLE_J1_TYPES_FOR_RESOURCE_KIND)
-  .concat([
-    SQL_ADMIN_MYSQL_INSTANCE_ENTITY_TYPE,
-    SQL_ADMIN_POSTGRES_INSTANCE_ENTITY_TYPE,
-    SQL_ADMIN_SQL_SERVER_INSTANCE_ENTITY_TYPE,
-  ]);
+const bindingResourceTargetTypes = Object.keys(J1_TYPE_TO_KEY_GENERATOR_MAP);
 
 /**
  * IAM policies can target any resource in Google Cloud. Because we do not ingest every resource,

--- a/src/steps/cloud-asset/index.ts
+++ b/src/steps/cloud-asset/index.ts
@@ -668,7 +668,7 @@ export async function createBindingToAnyResourceRelationships(
               relationshipDirection: RelationshipDirection.FORWARD,
               sourceEntityKey: bindingEntity._key,
               targetFilterKeys: [type ? ['_type', '_key'] : ['_key']],
-              skipTargetCreation: false,
+              skipTargetCreation: type ? false : true, // If we have a type, create target entity, if not, adoption does not work so skip target entity creation
               targetEntity: {
                 _type: type,
                 _key: key,

--- a/src/steps/cloud-asset/index.ts
+++ b/src/steps/cloud-asset/index.ts
@@ -692,12 +692,15 @@ function buildBindingEntityResourceKey(bindingEntity: BindingEntity) {
 }
 
 function isOrganizationalHierarchyResource(resourceType?: string) {
-  return [
-    ORGANIZATION_ENTITY_TYPE,
-    FOLDER_ENTITY_TYPE,
-    PROJECT_ENTITY_TYPE,
-    API_SERVICE_ENTITY_TYPE,
-  ].includes(resourceType as any);
+  return (
+    !!resourceType &&
+    [
+      ORGANIZATION_ENTITY_TYPE,
+      FOLDER_ENTITY_TYPE,
+      PROJECT_ENTITY_TYPE,
+      API_SERVICE_ENTITY_TYPE,
+    ].includes(resourceType)
+  );
 }
 
 function buildServiceGraphObjectKey(

--- a/src/steps/cloud-asset/index.ts
+++ b/src/steps/cloud-asset/index.ts
@@ -51,7 +51,6 @@ import {
   makeLogsForTypeAndKeyResponse,
 } from '../../utils/iamBindings/getTypeAndKeyFromResourceIdentifier';
 import { getEnabledServiceNames } from '../enablement';
-import { MULTIPLE_J1_TYPES_FOR_RESOURCE_KIND } from '../../utils/iamBindings/resourceKindToTypeMap';
 import { createIamRoleEntity } from '../iam/converters';
 import {
   basicRoles,
@@ -484,14 +483,6 @@ export function buildIamTargetRelationship({
             targetFilterKeys: targetEntity._key // Not always able to determine a _key for google_users depending on how the binding is set up
               ? [['_key', '_type']]
               : [['_type', 'email']],
-            /**
-             * The mapper does not properly remove mapper-created entities at the moment. These
-             * entities will never be cleaned up which will causes duplicates.
-             *
-             * However, we should still create these entities as they are important for access
-             * analysis. Without these relationships, it will make is look like something is
-             * secure when it actually is not. We will just have to deal with the duplicates.
-             */
             skipTargetCreation: false,
             targetEntity,
           },
@@ -655,9 +646,7 @@ export async function createBindingToAnyResourceRelationships(
             context,
           ),
         ) ?? {};
-      if (typeof type !== 'string' || typeof key !== 'string') {
-        return;
-      }
+      if (typeof key !== 'string') return;
       // Check to see if service is enabled prior to searching the jobState for an entity
       const service = getServiceFromResourceIdentifier(bindingEntity.resource);
       const existingEntity = enabledServiceNames.includes(service)
@@ -678,32 +667,13 @@ export async function createBindingToAnyResourceRelationships(
             _mapping: {
               relationshipDirection: RelationshipDirection.FORWARD,
               sourceEntityKey: bindingEntity._key,
-              targetFilterKeys: [
-                // Because there is no one-to-one-mapping from Google Resource Kind to J1 Type, only map on the `_key`.
-                type === MULTIPLE_J1_TYPES_FOR_RESOURCE_KIND
-                  ? ['_key']
-                  : ['_type', '_key'],
-              ],
-              /**
-               * The mapper does not properly remove mapper-created entities at the moment. These
-               * entities will never be cleaned up which will cause duplicates.
-               *
-               * Until this is fixed, we should not create mapped relationships with target creation
-               * enabled, thus only creating iam_binding relationships to resources that have already
-               * been ingested by other integrations.
-               *
-               * This is a BIG problem because we can no longer tell a customer with 100% confidence
-               * that they do not have any insecure resources if they have yet to have an integration
-               * ingest that resource.
-               */
-              skipTargetCreation: true,
+              targetFilterKeys: [type ? ['_type', '_key'] : ['_key']],
+              skipTargetCreation: false,
               targetEntity: {
-                // When there is no one-to-one-mapping from Google Resource Kind to J1 Type, do not set the _type on target entities.
-                _type:
-                  type === MULTIPLE_J1_TYPES_FOR_RESOURCE_KIND
-                    ? undefined
-                    : type,
+                _type: type,
                 _key: key,
+                name: bindingEntity.resource,
+                displayName: bindingEntity.resource,
                 resourceIdentifier: bindingEntity.resource,
               },
             },
@@ -721,13 +691,13 @@ function buildBindingEntityResourceKey(bindingEntity: BindingEntity) {
   );
 }
 
-function isOrganizationalHierarchyResource(resourceType: string) {
+function isOrganizationalHierarchyResource(resourceType?: string) {
   return [
     ORGANIZATION_ENTITY_TYPE,
     FOLDER_ENTITY_TYPE,
     PROJECT_ENTITY_TYPE,
     API_SERVICE_ENTITY_TYPE,
-  ].includes(resourceType);
+  ].includes(resourceType as any);
 }
 
 function buildServiceGraphObjectKey(
@@ -772,7 +742,7 @@ export async function createApiServiceToAnyResourceRelationships(
       ) ?? {};
 
       // Do NOT make relationships for resources in the Organization Resource Heirarchy.
-      if (isOrganizationalHierarchyResource(resourceType!)) return;
+      if (isOrganizationalHierarchyResource(resourceType)) return;
       if (!googleResourceKind || !resourceKey) return;
 
       const serviceIdentifier = googleResourceKind.split('/')[0]; // 'cloudfunctions.googleapis.com/CloudFunction' => 'cloudfunctions.googleapis.com'
@@ -780,20 +750,11 @@ export async function createApiServiceToAnyResourceRelationships(
         bindingEntity,
         serviceIdentifier,
       );
+
       const serviceEntity = await jobState.findEntity(serviceKey);
+      if (!serviceEntity) return;
+
       const resourceEntity = await jobState.findEntity(resourceKey);
-
-      // WARNING! TODO: We can not make these relationships for sqladmin.googleapis.com/Instances
-      // A Google Resource Type of sqladmin.googleapis.com/Instances could be a
-      // google_sql_mysql_instance, a google_sql_postgres_instance, or a
-      // google_sql_sql_server_instance. There is no way to tell at the moment.
-      if (
-        !serviceEntity ||
-        !resourceType ||
-        resourceType === MULTIPLE_J1_TYPES_FOR_RESOURCE_KIND
-      )
-        return;
-
       await jobState.addRelationship(
         resourceEntity
           ? createDirectRelationship({
@@ -807,20 +768,18 @@ export async function createApiServiceToAnyResourceRelationships(
           : createMappedRelationship({
               _class: RelationshipClass.HAS,
               _type: API_SERVICE_HAS_ANY_RESOURCE_TYPE,
-              source: serviceEntity,
-              /**
-               * The mapper does not properly remove mapper-created entities at the moment. These
-               * entities will never be cleaned up which will cause duplicates.
-               *
-               * Until this is fixed, we should not create mapped relationships with target creation
-               * enabled, thus only creating iam_binding relationships to resources that have already
-               * been ingested by other integrations.
-               */
-              skipTargetCreation: true,
-              target: {
-                _type: resourceType,
-                _key: resourceKey,
-                resourceIdentifier: bindingEntity.resource,
+              _mapping: {
+                relationshipDirection: RelationshipDirection.FORWARD,
+                sourceEntityKey: serviceEntity._key,
+                targetFilterKeys: [resourceType ? ['_type', '_key'] : ['_key']],
+                skipTargetCreation: false,
+                targetEntity: {
+                  _type: resourceType,
+                  _key: resourceKey,
+                  name: bindingEntity.resource,
+                  displayName: bindingEntity.resource,
+                  resourceIdentifier: bindingEntity.resource,
+                },
               },
             }),
       );

--- a/src/steps/cloud-asset/index.ts
+++ b/src/steps/cloud-asset/index.ts
@@ -668,12 +668,10 @@ export async function createBindingToAnyResourceRelationships(
               relationshipDirection: RelationshipDirection.FORWARD,
               sourceEntityKey: bindingEntity._key,
               targetFilterKeys: [type ? ['_type', '_key'] : ['_key']],
-              skipTargetCreation: type ? false : true, // If we have a type, create target entity, if not, adoption does not work so skip target entity creation
+              skipTargetCreation: true, // Each project should be in charge of ingesting its own resources
               targetEntity: {
                 _type: type,
                 _key: key,
-                name: bindingEntity.resource,
-                displayName: bindingEntity.resource,
                 resourceIdentifier: bindingEntity.resource,
               },
             },
@@ -775,12 +773,10 @@ export async function createApiServiceToAnyResourceRelationships(
                 relationshipDirection: RelationshipDirection.FORWARD,
                 sourceEntityKey: serviceEntity._key,
                 targetFilterKeys: [resourceType ? ['_type', '_key'] : ['_key']],
-                skipTargetCreation: false,
+                skipTargetCreation: true, // Each project should be in charge of ingesting its own resources.
                 targetEntity: {
                   _type: resourceType,
                   _key: resourceKey,
-                  name: bindingEntity.resource,
-                  displayName: bindingEntity.resource,
                   resourceIdentifier: bindingEntity.resource,
                 },
               },

--- a/src/utils/iamBindings/__snapshots__/getTypeAndKeyFromResourceIdentifier.test.ts.snap
+++ b/src/utils/iamBindings/__snapshots__/getTypeAndKeyFromResourceIdentifier.test.ts.snap
@@ -692,7 +692,7 @@ exports[`getTypeAndKeyFromResourceIdentifier should find the correct keys for al
 Object {
   "identifier": "//cloudsql.googleapis.com/projects/12345/instances/abcdef12345",
   "key": "https://www.googleapis.com/cloudsql/projects/12345/instances/abcdef12345",
-  "type": "MULTIPLE_J1_TYPES_FOR_RESOURCE_KIND",
+  "type": undefined,
 }
 `;
 

--- a/src/utils/iamBindings/getTypeAndKeyFromResourceIdentifier.test.ts
+++ b/src/utils/iamBindings/getTypeAndKeyFromResourceIdentifier.test.ts
@@ -13,7 +13,7 @@ import {
   makeLogsForTypeAndKeyResponse,
   TypeAndKey,
 } from './getTypeAndKeyFromResourceIdentifier';
-import { NONE } from './resourceKindToTypeMap';
+import { J1_TYPES_WITHOUT_A_UNIQUE_KIND, NONE } from './resourceKindToTypeMap';
 import {
   impossible,
   J1_TYPE_TO_KEY_GENERATOR_MAP,
@@ -21,7 +21,7 @@ import {
 
 const jupiterOneTypesWithMappedGoogleResources = Object.keys(
   pickBy(J1_TYPE_TO_KEY_GENERATOR_MAP, (keyMethod) => keyMethod !== impossible),
-);
+).filter((type) => !J1_TYPES_WITHOUT_A_UNIQUE_KIND.includes(type));
 
 describe('getTypeAndKeyFromResourceIdentifier', () => {
   it(`should find the correct keys for all available resources`, async () => {
@@ -64,7 +64,7 @@ describe('makeLogsForTypeAndKeyResponse', () => {
     };
     const logger = getMockLogger<IntegrationLogger>();
     makeLogsForTypeAndKeyResponse(logger, typeAndKeyResponse);
-    expect(logger.warn).toHaveBeenCalledWith(
+    expect(logger.info).toHaveBeenCalledWith(
       typeAndKeyResponse,
       'Unable to find J1 type from google cloud resource.',
     );

--- a/src/utils/iamBindings/resourceKindToTypeMap.ts
+++ b/src/utils/iamBindings/resourceKindToTypeMap.ts
@@ -78,14 +78,30 @@ import {
   ENTITY_TYPE_SPANNER_INSTANCE,
   ENTITY_TYPE_SPANNER_INSTANCE_DATABASE,
 } from '../../steps/spanner/constants';
+import {
+  SQL_ADMIN_MYSQL_INSTANCE_ENTITY_TYPE,
+  SQL_ADMIN_POSTGRES_INSTANCE_ENTITY_TYPE,
+  SQL_ADMIN_SQL_SERVER_INSTANCE_ENTITY_TYPE,
+} from '../../steps/sql-admin';
 import { CLOUD_STORAGE_BUCKET_ENTITY_TYPE } from '../../steps/storage';
 
 // Indicates JupiterOne is not ingesting that resource yet.
 export const NONE = 'NO_DIRECT_J1_RESOURCE_YET';
 
-// Because the SQL_INSTANCE resource kind was split into 3 J1 resource _types, we need to treat it differently from all the others.
-export const MULTIPLE_J1_TYPES_FOR_RESOURCE_KIND =
-  'MULTIPLE_J1_TYPES_FOR_RESOURCE_KIND';
+/**
+ * NOTE: Because a kind of "sqladmin.googleapis.com/Instance" can be a
+ * "google_sql_mysql_instance", "google_sql_postgres_instance", or
+ * "google_sql_sql_server_instance", we assign it to
+ * "google_sql_sql_server_instance" because they all have the same
+ * key generation funciton.
+ */
+export const SQL_ENTITY_TYPE = SQL_ADMIN_MYSQL_INSTANCE_ENTITY_TYPE;
+
+export const J1_TYPES_WITHOUT_A_UNIQUE_KIND = [
+  SQL_ADMIN_MYSQL_INSTANCE_ENTITY_TYPE,
+  SQL_ADMIN_POSTGRES_INSTANCE_ENTITY_TYPE,
+  SQL_ADMIN_SQL_SERVER_INSTANCE_ENTITY_TYPE,
+];
 
 /**
  * A map of all existing Google Cloud resources to their associated JupiterOne type
@@ -211,7 +227,7 @@ export const GOOGLE_RESOURCE_KIND_TO_J1_TYPE_MAP: {
   'secretmanager.googleapis.com/SecretVersion': NONE,
   'tpu.googleapis.com/Node': NONE,
   'composer.googleapis.com/Environment': NONE,
-  'sqladmin.googleapis.com/Instance': MULTIPLE_J1_TYPES_FOR_RESOURCE_KIND,
+  'sqladmin.googleapis.com/Instance': SQL_ENTITY_TYPE,
   'file.googleapis.com/Instance': NONE,
   'file.googleapis.com/Backup': NONE,
   'servicedirectory.googleapis.com/Namespace': NONE,

--- a/src/utils/iamBindings/typeToKeyGeneratorMap.test.ts
+++ b/src/utils/iamBindings/typeToKeyGeneratorMap.test.ts
@@ -32,11 +32,6 @@ import { ENTITY_TYPE_PRIVATE_CA_CERTIFICATE } from '../../steps/privateca/consta
 import { ENTITY_TYPE_SPANNER_INSTANCE_CONFIG } from '../../steps/spanner/constants';
 import { J1_TYPE_TO_KEY_GENERATOR_MAP } from './typeToKeyGeneratorMap';
 import { GOOGLE_RESOURCE_KIND_TO_J1_TYPE_MAP } from './resourceKindToTypeMap';
-import {
-  SQL_ADMIN_MYSQL_INSTANCE_ENTITY_TYPE,
-  SQL_ADMIN_POSTGRES_INSTANCE_ENTITY_TYPE,
-  SQL_ADMIN_SQL_SERVER_INSTANCE_ENTITY_TYPE,
-} from '../../steps/sql-admin';
 import { invocationConfig } from '../..';
 import {
   generateRelationshipType,
@@ -80,21 +75,6 @@ const entitiesTypesToSkip = [
   ENTITY_TYPE_SPANNER_INSTANCE_CONFIG,
 ];
 
-/**
- * HACK: sqladmin.googleapis.com/Instances are currently mapped incorrectly.
- * A Google Resource Type of sqladmin.googleapis.com/Instances could be a
- * google_sql_mysql_instance, a google_sql_postgres_instance, or a
- * google_sql_sql_server_instance. There is no way to tell at the moment.
- *
- * These tests have value right now though, so adding this temporary hack
- * to skip sqladmin instances.
- */
-const HACK_SKIP_UNTIL_SQL_INSTANCES_ARE_FIXED = [
-  SQL_ADMIN_MYSQL_INSTANCE_ENTITY_TYPE,
-  SQL_ADMIN_POSTGRES_INSTANCE_ENTITY_TYPE,
-  SQL_ADMIN_SQL_SERVER_INSTANCE_ENTITY_TYPE,
-]; // will be fixed with https://jupiterone.atlassian.net/browse/INT-1303
-
 describe('J1_TYPE_TO_KEY_GENERATOR_MAP', () => {
   test('All resource entities that can be targeted by an IAM Binding should be documented in the stepMetadata', () => {
     const metadata = collectGraphObjectMetadataFromSteps(
@@ -108,7 +88,6 @@ describe('J1_TYPE_TO_KEY_GENERATOR_MAP', () => {
     metadata.entities.forEach((entity) => {
       if (!entitiesTypesToSkip.includes(entity._type)) {
         if (!bindingRelationships.find((r) => r.targetType == entity._type)) {
-          console.log(entity._type);
           unmappedEntities.push(entity._type);
         }
       }
@@ -123,12 +102,7 @@ describe('J1_TYPE_TO_KEY_GENERATOR_MAP', () => {
     const unmappedEntities: string[] = [];
 
     metadata.entities.forEach((entity) => {
-      if (
-        ![
-          ...entitiesTypesToSkip,
-          ...HACK_SKIP_UNTIL_SQL_INSTANCES_ARE_FIXED,
-        ].includes(entity._type)
-      ) {
+      if (!entitiesTypesToSkip.includes(entity._type)) {
         if (typeof J1_TYPE_TO_KEY_GENERATOR_MAP[entity._type] != 'function') {
           unmappedEntities.push(entity._type);
         }
@@ -146,12 +120,7 @@ describe('GOOGLE_RESOURCE_KIND_TO_J1_TYPE_MAP', () => {
     const unmappedEntities: string[] = [];
 
     metadata.entities.forEach((entity) => {
-      if (
-        ![
-          ...entitiesTypesToSkip,
-          ...HACK_SKIP_UNTIL_SQL_INSTANCES_ARE_FIXED,
-        ].includes(entity._type)
-      ) {
+      if (!entitiesTypesToSkip.includes(entity._type)) {
         if (
           !Object.values(GOOGLE_RESOURCE_KIND_TO_J1_TYPE_MAP).includes(
             entity._type,

--- a/src/utils/iamBindings/typeToKeyGeneratorMap.ts
+++ b/src/utils/iamBindings/typeToKeyGeneratorMap.ts
@@ -1,4 +1,3 @@
-import { MULTIPLE_J1_TYPES_FOR_RESOURCE_KIND } from './resourceKindToTypeMap';
 import {
   ENTITY_TYPE_API_GATEWAY_API,
   ENTITY_TYPE_API_GATEWAY_API_CONFIG,
@@ -92,6 +91,11 @@ import {
   ENTITY_TYPE_BIG_TABLE_BACKUP,
 } from '../../steps/big-table/constants';
 import { ENTITY_TYPE_BILLING_ACCOUNT } from '../../steps/cloud-billing/constants';
+import {
+  SQL_ADMIN_MYSQL_INSTANCE_ENTITY_TYPE,
+  SQL_ADMIN_POSTGRES_INSTANCE_ENTITY_TYPE,
+  SQL_ADMIN_SQL_SERVER_INSTANCE_ENTITY_TYPE,
+} from '../../steps/sql-admin';
 
 /**
  * A map of JupiterOne types to a function which can generate their _key
@@ -167,7 +171,6 @@ export const J1_TYPE_TO_KEY_GENERATOR_MAP: {
   [ENTITY_TYPE_REDIS_INSTANCE]: customPrefixAndIdKeyMap(getRedisKey),
   [ENTITY_TYPE_MEMCACHE_INSTANCE]: customPrefixAndIdKeyMap(getMemcacheKey),
   [MONITORING_ALERT_POLICY_TYPE]: fullPathKeyMap,
-  [MULTIPLE_J1_TYPES_FOR_RESOURCE_KIND]: selfLinkKeyMap,
   [ENTITY_TYPE_DATAPROC_CLUSTER]: fullPathKeyMap,
   [ENTITY_TYPE_BIG_TABLE_INSTANCE]: fullPathKeyMap,
   [ENTITY_TYPE_BIG_TABLE_CLUSTER]: fullPathKeyMap,
@@ -176,6 +179,9 @@ export const J1_TYPE_TO_KEY_GENERATOR_MAP: {
   [ENTITY_TYPE_BIG_TABLE_BACKUP]: fullPathKeyMap,
   [ENTITY_TYPE_BILLING_ACCOUNT]: fullPathKeyMap,
   [DNS_POLICY_ENTITY_TYPE]: fullPathKeyMap,
+  [SQL_ADMIN_MYSQL_INSTANCE_ENTITY_TYPE]: selfLinkKeyMap,
+  [SQL_ADMIN_POSTGRES_INSTANCE_ENTITY_TYPE]: selfLinkKeyMap,
+  [SQL_ADMIN_SQL_SERVER_INSTANCE_ENTITY_TYPE]: selfLinkKeyMap,
 };
 
 // ex: projects/j1-gc-integration-dev-v3/locations/us-central1/functions/j1-gc-integration-dev-v3testfunction


### PR DESCRIPTION
It might make sense to have these `_types` be all the same in order to more accurately map to what Google Cloud thinks about these SQL instance entities. However, that requires changing managed question and notifying customers. 

The code to do that is https://github.com/JupiterOne/graph-google-cloud/pull/376

...which is quite expensive and a big hassle as we have already created managed questions for this data model. Because of this it is likely better to just stick with the existing types.