### PR TITLE
Add managed question for useRoutes

### DIFF
--- a/jupiterone/questions/questions.yaml
+++ b/jupiterone/questions/questions.yaml
@@ -16,6 +16,17 @@ questions:
   - google-cloud
   - service
   - api
+- id: integration-question-google-cloud-kubernetes-route-based-clusters
+  title: Which Kubernetes clusters use Google Cloud Routes for traffic routing between pods?
+  description:
+    Finds all Kubernetes clusters that are routes-based clusters
+  queries:
+  - query: |
+      FIND google_container_cluster WITH useRoutes = true
+  tags:
+  - google-cloud
+  - gke
+  - network
 ################################################################################
 # End generic non-compliance questions
 ################################################################################


### PR DESCRIPTION
Very simple PR that just adds one managed question for a property that's been covered already - in light of recent customer requests regarding GCP's Kubernetes.

@austinkelleher 