### PR TITLE
Ensure that both IAM and Cloud Asset APIs are enabled to run Cloud Asset steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `createStepStartStateWhereAllServicesMustBeEnabled` method to allow specifying
+  that a step requires more than one API to be enabled to run.
+
+### Fixed
+
+- Only enable `google_iam_binding` steps if both the `iam.googleapis.com` api
+  and the `cloudasset.googleapis.com` api is enabled.
+
 ## 2.2.0 - 2021-11-04
 
 ### Fixed

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -241,6 +241,17 @@ export default async function getStepStartStates(
     );
   };
 
+  const createStepStartStateWhereAllServicesMustBeEnabled = (
+    primaryServiceName: ServiceUsageName,
+    ...additionalServiceNames: ServiceUsageName[]
+  ): StepStartState => {
+    return enablement.createStepStartStateWhereAllServicesMustBeEnabled(
+      enabledServiceNames,
+      primaryServiceName,
+      ...additionalServiceNames,
+    );
+  };
+
   function createOrgStepStartState(
     primaryServiceName: ServiceUsageName,
     ...additionalServiceNames: ServiceUsageName[]
@@ -269,30 +280,35 @@ export default async function getStepStartStates(
     // This API will be enabled otherwise fetching services names above would fail
     [STEP_RESOURCE_MANAGER_PROJECT]: { disabled: false },
     [STEP_API_SERVICES]: { disabled: false },
-    [STEP_IAM_BINDINGS]: createStepStartState(
+    [STEP_IAM_BINDINGS]: createStepStartStateWhereAllServicesMustBeEnabled(
       ServiceUsageName.CLOUD_ASSET,
       ServiceUsageName.IAM,
     ),
-    [STEP_CREATE_BASIC_ROLES]: createStepStartState(
-      ServiceUsageName.CLOUD_ASSET,
-      ServiceUsageName.IAM,
-    ),
-    [STEP_CREATE_BINDING_PRINCIPAL_RELATIONSHIPS]: createStepStartState(
-      ServiceUsageName.CLOUD_ASSET,
-      ServiceUsageName.IAM,
-    ),
-    [STEP_CREATE_BINDING_ROLE_RELATIONSHIPS]: createStepStartState(
-      ServiceUsageName.CLOUD_ASSET,
-      ServiceUsageName.IAM,
-    ),
-    [STEP_CREATE_BINDING_ANY_RESOURCE_RELATIONSHIPS]: createStepStartState(
-      ServiceUsageName.CLOUD_ASSET,
-      ServiceUsageName.IAM,
-    ),
-    [STEP_CREATE_API_SERVICE_ANY_RESOURCE_RELATIONSHIPS]: createStepStartState(
-      ServiceUsageName.CLOUD_ASSET,
-      ServiceUsageName.IAM,
-    ),
+    [STEP_CREATE_BASIC_ROLES]:
+      createStepStartStateWhereAllServicesMustBeEnabled(
+        ServiceUsageName.CLOUD_ASSET,
+        ServiceUsageName.IAM,
+      ),
+    [STEP_CREATE_BINDING_PRINCIPAL_RELATIONSHIPS]:
+      createStepStartStateWhereAllServicesMustBeEnabled(
+        ServiceUsageName.CLOUD_ASSET,
+        ServiceUsageName.IAM,
+      ),
+    [STEP_CREATE_BINDING_ROLE_RELATIONSHIPS]:
+      createStepStartStateWhereAllServicesMustBeEnabled(
+        ServiceUsageName.CLOUD_ASSET,
+        ServiceUsageName.IAM,
+      ),
+    [STEP_CREATE_BINDING_ANY_RESOURCE_RELATIONSHIPS]:
+      createStepStartStateWhereAllServicesMustBeEnabled(
+        ServiceUsageName.CLOUD_ASSET,
+        ServiceUsageName.IAM,
+      ),
+    [STEP_CREATE_API_SERVICE_ANY_RESOURCE_RELATIONSHIPS]:
+      createStepStartStateWhereAllServicesMustBeEnabled(
+        ServiceUsageName.CLOUD_ASSET,
+        ServiceUsageName.IAM,
+      ),
     [STEP_CLOUD_FUNCTIONS]: createStepStartState(
       ServiceUsageName.CLOUD_FUNCTIONS,
     ),

--- a/src/steps/enablement.test.ts
+++ b/src/steps/enablement.test.ts
@@ -71,6 +71,37 @@ describe('#createStepStartState', () => {
   });
 });
 
+describe('#createStepStartStateWhereAllServicesMustBeEnabled', () => {
+  test('should enable if all service names are enabled', () => {
+    expect(
+      enablement.createStepStartStateWhereAllServicesMustBeEnabled(
+        [
+          'storage.googleapis.com',
+          'storage-component.googleapis.com',
+          'storage-api.googleapis.com',
+        ],
+        ServiceUsageName.STORAGE,
+        ServiceUsageName.STORAGE_COMPONENT,
+        ServiceUsageName.STORAGE_API,
+      ),
+    ).toEqual({
+      disabled: false,
+    });
+  });
+  test('should not enable if not all service names are enabled', () => {
+    expect(
+      enablement.createStepStartStateWhereAllServicesMustBeEnabled(
+        ['storage-component.googleapis.com'],
+        ServiceUsageName.STORAGE,
+        ServiceUsageName.STORAGE_COMPONENT,
+        ServiceUsageName.STORAGE_API,
+      ),
+    ).toEqual({
+      disabled: true,
+    });
+  });
+});
+
 describe('#getEnabledServiceNames', () => {
   beforeEach(() => {
     jest.resetAllMocks();

--- a/src/steps/enablement.ts
+++ b/src/steps/enablement.ts
@@ -104,3 +104,22 @@ export function createStepStartState(
 
   return { disabled };
 }
+
+export function createStepStartStateWhereAllServicesMustBeEnabled(
+  enabledServiceNames: string[],
+  primaryServiceName: ServiceUsageName,
+  ...additionalServiceNames: ServiceUsageName[]
+): StepStartState {
+  const allServicesToEnableStep: ServiceUsageName[] = [
+    primaryServiceName,
+    ...additionalServiceNames,
+  ];
+
+  for (const serviceName of allServicesToEnableStep) {
+    if (!enabledServiceNames.includes(serviceName)) {
+      return { disabled: true };
+    }
+  }
+
+  return { disabled: false };
+}


### PR DESCRIPTION
Fixing an issue from a deploy earlier today where I thought `createStepStartState` would require both services to be enabled in order to enable the step. Instead it just checks if one of the services is required. I added a new method `createStepStartStateWhereAllServicesMustBeEnabled` to make this more clear.