### PR TITLE
Fix binding allows any resource mapped relationships to use ALLOWS instead of HAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `google_iam_binding_allows_resource` mapped relationships will now be created
+  with an `ALLOWS` class instead of `HAS`.
+
 ## 2.3.0 - 2021-11-08
 
 ### Changed

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -457,7 +457,7 @@ The following relationships are created:
 | `google_dataproc_cluster`                                        | **USES**              | `google_kms_crypto_key`                                           |
 | `google_dataproc_cluster`                                        | **USES**              | `google_storage_bucket`                                           |
 | `google_cloud_folder`                                            | **HAS**               | `google_cloud_project`                                            |
-| `google_cloud_api_service`                                       | **HAS**               | `resource`                                                        |
+| `google_iam_binding`                                             | **ALLOWS**            | `resource`                                                        |
 | `google_iam_binding`                                             | **ASSIGNED**          | `google_cloud_authenticated_users`                                |
 | `google_iam_binding`                                             | **ASSIGNED**          | `google_domain`                                                   |
 | `google_iam_binding`                                             | **ASSIGNED**          | `everyone`                                                        |

--- a/src/steps/cloud-asset/constants.ts
+++ b/src/steps/cloud-asset/constants.ts
@@ -3,7 +3,6 @@ import {
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import { ANY_RESOURCE } from '../../constants';
-import { J1_TYPE_TO_KEY_GENERATOR_MAP } from '../../utils/iamBindings/typeToKeyGeneratorMap';
 import {
   ALL_AUTHENTICATED_USERS_TYPE,
   EVERYONE_TYPE,
@@ -62,66 +61,36 @@ export const BINDING_ASSIGNED_PRINCIPAL_RELATIONSHIPS = IAM_PRINCIPAL_TYPES.map(
   },
 );
 
-const bindingResourceTargetTypes = Object.keys(J1_TYPE_TO_KEY_GENERATOR_MAP);
-
 /**
  * IAM policies can target any resource in Google Cloud. Because we do not ingest every resource,
  * we have chosen, instead, to represent the relationship as IAM Binding assigned to ANY_RESOURCE.
  */
-export const BINDING_ALLOWS_ANY_RESOURCE_TYPE = generateRelationshipType(
-  RelationshipClass.ALLOWS,
-  bindingEntities.BINDINGS._type,
-  ANY_RESOURCE,
-);
-export const BINDING_ALLOWS_ANY_RESOURCE_RELATIONSHIPS = [
-  {
-    // Needed for documentation
-    _class: RelationshipClass.HAS,
-    _type: BINDING_ALLOWS_ANY_RESOURCE_TYPE,
-    sourceType: API_SERVICE_ENTITY_TYPE,
-    targetType: ANY_RESOURCE,
-    indexMetadata: {
-      enabled: false,
-    },
+export const BINDING_ALLOWS_ANY_RESOURCE_RELATIONSHIP = {
+  // Needed for documentation
+  _class: RelationshipClass.ALLOWS,
+  _type: generateRelationshipType(
+    RelationshipClass.ALLOWS,
+    bindingEntities.BINDINGS._type,
+    ANY_RESOURCE,
+  ),
+  sourceType: bindingEntities.BINDINGS._type,
+  targetType: ANY_RESOURCE,
+  indexMetadata: {
+    enabled: false,
   },
-  ...bindingResourceTargetTypes.map((resourceType) => {
-    return {
-      _type: BINDING_ALLOWS_ANY_RESOURCE_TYPE,
-      sourceType: bindingEntities.BINDINGS._type,
-      _class: RelationshipClass.ALLOWS,
-      targetType: resourceType,
-      indexMetadata: {
-        enabled: false,
-      },
-    };
-  }),
-];
+};
 
-export const API_SERVICE_HAS_ANY_RESOURCE_TYPE = generateRelationshipType(
-  RelationshipClass.HAS,
-  API_SERVICE_ENTITY_TYPE,
-  ANY_RESOURCE,
-);
-export const API_SERVICE_HAS_ANY_RESOURCE_RELATIONSHIPS = [
-  {
-    // Needed for documentation
-    _class: RelationshipClass.HAS,
-    _type: API_SERVICE_HAS_ANY_RESOURCE_TYPE,
-    sourceType: API_SERVICE_ENTITY_TYPE,
-    targetType: ANY_RESOURCE,
-    indexMetadata: {
-      enabled: false,
-    },
+export const API_SERVICE_HAS_ANY_RESOURCE_RELATIONSHIP = {
+  // Needed for documentation
+  _class: RelationshipClass.HAS,
+  _type: generateRelationshipType(
+    RelationshipClass.HAS,
+    API_SERVICE_ENTITY_TYPE,
+    ANY_RESOURCE,
+  ),
+  sourceType: API_SERVICE_ENTITY_TYPE,
+  targetType: ANY_RESOURCE,
+  indexMetadata: {
+    enabled: false,
   },
-  ...bindingResourceTargetTypes.map((resourceType) => {
-    return {
-      _class: RelationshipClass.HAS,
-      _type: API_SERVICE_HAS_ANY_RESOURCE_TYPE,
-      sourceType: API_SERVICE_ENTITY_TYPE,
-      targetType: resourceType,
-      indexMetadata: {
-        enabled: false,
-      },
-    };
-  }),
-];
+};

--- a/src/steps/cloud-asset/index.ts
+++ b/src/steps/cloud-asset/index.ts
@@ -28,11 +28,9 @@ import {
 } from '../resource-manager';
 import { CloudAssetClient } from './client';
 import {
-  API_SERVICE_HAS_ANY_RESOURCE_RELATIONSHIPS,
-  API_SERVICE_HAS_ANY_RESOURCE_TYPE,
+  API_SERVICE_HAS_ANY_RESOURCE_RELATIONSHIP,
   bindingEntities,
-  BINDING_ALLOWS_ANY_RESOURCE_RELATIONSHIPS,
-  BINDING_ALLOWS_ANY_RESOURCE_TYPE,
+  BINDING_ALLOWS_ANY_RESOURCE_RELATIONSHIP,
   BINDING_ASSIGNED_PRINCIPAL_RELATIONSHIPS,
   STEP_CREATE_API_SERVICE_ANY_RESOURCE_RELATIONSHIPS,
   STEP_CREATE_BASIC_ROLES,
@@ -659,15 +657,15 @@ export async function createBindingToAnyResourceRelationships(
       const relationship = existingEntity
         ? createDirectRelationship({
             from: bindingEntity,
-            _class: RelationshipClass.ALLOWS,
+            _class: BINDING_ALLOWS_ANY_RESOURCE_RELATIONSHIP._class,
             to: existingEntity,
             properties: {
-              _type: BINDING_ALLOWS_ANY_RESOURCE_TYPE,
+              _type: BINDING_ALLOWS_ANY_RESOURCE_RELATIONSHIP._type,
             },
           })
         : createMappedRelationship({
-            _class: BINDING_ALLOWS_ANY_RESOURCE_RELATIONSHIPS[0]._class,
-            _type: BINDING_ALLOWS_ANY_RESOURCE_TYPE,
+            _class: BINDING_ALLOWS_ANY_RESOURCE_RELATIONSHIP._class,
+            _type: BINDING_ALLOWS_ANY_RESOURCE_RELATIONSHIP._type,
             _mapping: {
               relationshipDirection: RelationshipDirection.FORWARD,
               sourceEntityKey: bindingEntity._key,
@@ -763,16 +761,16 @@ export async function createApiServiceToAnyResourceRelationships(
       await jobState.addRelationship(
         resourceEntity
           ? createDirectRelationship({
-              _class: RelationshipClass.HAS,
+              _class: API_SERVICE_HAS_ANY_RESOURCE_RELATIONSHIP._class,
               from: serviceEntity,
               to: resourceEntity,
               properties: {
-                _type: API_SERVICE_HAS_ANY_RESOURCE_TYPE,
+                _type: API_SERVICE_HAS_ANY_RESOURCE_RELATIONSHIP._type,
               },
             })
           : createMappedRelationship({
-              _class: RelationshipClass.HAS,
-              _type: API_SERVICE_HAS_ANY_RESOURCE_TYPE,
+              _class: API_SERVICE_HAS_ANY_RESOURCE_RELATIONSHIP._class,
+              _type: API_SERVICE_HAS_ANY_RESOURCE_RELATIONSHIP._type,
               _mapping: {
                 relationshipDirection: RelationshipDirection.FORWARD,
                 sourceEntityKey: serviceEntity._key,
@@ -851,7 +849,7 @@ export const cloudAssetSteps: IntegrationStep<IntegrationConfig>[] = [
     id: STEP_CREATE_BINDING_ANY_RESOURCE_RELATIONSHIPS,
     name: 'Role Binding to Any Resource Relationships',
     entities: [],
-    relationships: [...BINDING_ALLOWS_ANY_RESOURCE_RELATIONSHIPS],
+    relationships: [BINDING_ALLOWS_ANY_RESOURCE_RELATIONSHIP],
     dependsOn: [STEP_IAM_BINDINGS],
     executionHandler: createBindingToAnyResourceRelationships,
     dependencyGraphId: 'last',
@@ -860,7 +858,7 @@ export const cloudAssetSteps: IntegrationStep<IntegrationConfig>[] = [
     id: STEP_CREATE_API_SERVICE_ANY_RESOURCE_RELATIONSHIPS,
     name: 'Api Service to Any Resource Relationships',
     entities: [],
-    relationships: [...API_SERVICE_HAS_ANY_RESOURCE_RELATIONSHIPS],
+    relationships: [API_SERVICE_HAS_ANY_RESOURCE_RELATIONSHIP],
     dependsOn: [STEP_IAM_BINDINGS],
     executionHandler: createApiServiceToAnyResourceRelationships,
     dependencyGraphId: 'last',

--- a/src/utils/iamBindings/typeToKeyGeneratorMap.test.ts
+++ b/src/utils/iamBindings/typeToKeyGeneratorMap.test.ts
@@ -1,6 +1,6 @@
 import {
   bindingEntities,
-  BINDING_ALLOWS_ANY_RESOURCE_TYPE,
+  BINDING_ALLOWS_ANY_RESOURCE_RELATIONSHIP,
 } from '../../steps/cloud-asset/constants';
 import {
   ENTITY_TYPE_ACCESS_CONTEXT_MANAGER_ACCESS_LEVEL,
@@ -82,7 +82,7 @@ describe('J1_TYPE_TO_KEY_GENERATOR_MAP', () => {
     );
     const unmappedEntities: string[] = [];
     const bindingRelationships = metadata.relationships.filter(
-      (r) => r._type === BINDING_ALLOWS_ANY_RESOURCE_TYPE,
+      (r) => r._type === BINDING_ALLOWS_ANY_RESOURCE_RELATIONSHIP._type,
     );
 
     metadata.entities.forEach((entity) => {


### PR DESCRIPTION
`google_iam_binding_allows_resource` mapped relationships were getting created with a class of `HAS` instead of `ALLOWS`.

There was also a documentation issue where the `BINDING_ALLOWS_ANY_RESOURCE_RELATIONSHIP` stepMetadata was incorrect, which _might_ (unsure) have been causing partial_types to not have been specified properly during execution.
