### PR TITLE
INTS-122 - Do not store projectId on entities that are not related to the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Removed
+
+- Properties were removed from resources:
+
+  | Entity                            | Properties             |
+  | --------------------------------- | ---------------------- |
+  | `google_cloud_folder`             | `projectId`            |
+  | `google_cloud_organization`       | `projectId`, `folders` |
+  | folder level `google_iam_binding` | `projectId`            |
+  | org level `google_iam_binding`    | `projectId`, `folders` |
+
 ## 2.5.0 - 2021-12-06
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,4 @@
-import {
-  Entity,
-  IntegrationInvocationConfig,
-} from '@jupiterone/integration-sdk-core';
+import { IntegrationInvocationConfig } from '@jupiterone/integration-sdk-core';
 import { deserializeIntegrationConfig } from './utils/integrationConfig';
 import { IntegrationConfig } from './types';
 import getStepStartStates from './getStepStartStates';
@@ -35,6 +32,7 @@ import { cloudBillingSteps } from './steps/cloud-billing';
 import { Client } from './google-cloud/client';
 import { cloudAssetSteps } from './steps/cloud-asset';
 import { bigTableSteps } from './steps/big-table';
+import { maybeDefaultProjectIdOnEntity } from './utils/maybeDefaultProjectIdOnEntity';
 
 export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> =
   {
@@ -86,16 +84,7 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> =
       ...cloudBillingSteps,
     ],
     dependencyGraphOrder: ['last'],
-    beforeAddEntity(context, entity: Entity): Entity {
-      const projectId =
-        context.instance.config.projectId ||
-        context.instance.config.serviceAccountKeyConfig.project_id;
-
-      return {
-        ...entity,
-        projectId: entity.projectId || projectId,
-      };
-    },
+    beforeAddEntity: maybeDefaultProjectIdOnEntity,
   };
 
 export {

--- a/src/steps/cloud-asset/index.ts
+++ b/src/steps/cloud-asset/index.ts
@@ -691,6 +691,11 @@ function buildBindingEntityResourceKey(bindingEntity: BindingEntity) {
   );
 }
 
+/**
+ * Returns true if the passed in _type relates to an entity
+ * that is a part of the Google Cloud Resource Hierarchy.
+ * https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy
+ */
 function isOrganizationalHierarchyResource(resourceType?: string) {
   return (
     !!resourceType &&

--- a/src/steps/compute/__snapshots__/index.test.ts.snap
+++ b/src/steps/compute/__snapshots__/index.test.ts.snap
@@ -16621,7 +16621,7 @@ Object {
       "_class": Array [
         "Image",
       ],
-      "_key": undefined,
+      "_key": "j1-gc-integration-dev-v3:example-snapshot-image:deleted",
       "_rawData": Array [
         Object {
           "name": "default",
@@ -17209,8 +17209,8 @@ Object {
     Object {
       "_class": "USES",
       "_fromEntityKey": "disk:3169341475684659331",
-      "_key": "disk:3169341475684659331|uses|undefined",
-      "_toEntityKey": undefined,
+      "_key": "disk:3169341475684659331|uses|j1-gc-integration-dev-v3:example-snapshot-image:deleted",
+      "_toEntityKey": "j1-gc-integration-dev-v3:example-snapshot-image:deleted",
       "_type": "google_compute_disk_uses_image",
       "displayName": "USES",
     },

--- a/src/utils/maybeDefaultProjectIdOnEntity.test.ts
+++ b/src/utils/maybeDefaultProjectIdOnEntity.test.ts
@@ -1,0 +1,98 @@
+import { Entity } from '@jupiterone/integration-sdk-core';
+import { createMockStepExecutionContext } from '@jupiterone/integration-sdk-testing';
+import { IntegrationConfig } from '..';
+import { integrationConfig } from '../../test/config';
+import { bindingEntities } from '../steps/cloud-asset/constants';
+import {
+  ORGANIZATION_ENTITY_TYPE,
+  FOLDER_ENTITY_TYPE,
+} from '../steps/resource-manager';
+import { maybeDefaultProjectIdOnEntity } from './maybeDefaultProjectIdOnEntity';
+
+describe('maybeDefaultProjectIdOnEntity', () => {
+  test.each([
+    ORGANIZATION_ENTITY_TYPE,
+    FOLDER_ENTITY_TYPE,
+    bindingEntities.BINDINGS._type,
+  ])(`should not default a projectId on %s entities`, (entityType) => {
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig: {
+        ...integrationConfig,
+        projectId: 'someId',
+      },
+    });
+    const mockEntity: Entity = {
+      _key: 'abc',
+      _class: 'Resource',
+      _type: entityType,
+    };
+    const expected = Object.assign({}, mockEntity);
+    expect(maybeDefaultProjectIdOnEntity(context, mockEntity)).toEqual(
+      expected,
+    );
+  });
+
+  test(`should maintain the entity's projectId if it was previously specified`, () => {
+    const projectId = 'entitySpecificProjectId';
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig: {
+        ...integrationConfig,
+        projectId: 'someId',
+      },
+    });
+    const mockEntity: Entity = {
+      _key: 'abc',
+      _class: 'Resource',
+      _type: 'type',
+      projectId,
+    };
+    expect(maybeDefaultProjectIdOnEntity(context, mockEntity).projectId).toBe(
+      projectId,
+    );
+  });
+
+  test(`should default to the config's projectId`, () => {
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig: {
+        ...integrationConfig,
+        projectId: 'someId',
+      },
+    });
+    const configProjectId = context.instance.config.projectId;
+    const serviceAccountProjectId =
+      context.instance.config.serviceAccountKeyConfig.project_id;
+    const mockEntity: Entity = {
+      _key: 'abc',
+      _class: 'Resource',
+      _type: 'type',
+    };
+    expect(configProjectId).toBeTruthy();
+    expect(serviceAccountProjectId).toBeTruthy();
+    expect(maybeDefaultProjectIdOnEntity(context, mockEntity).projectId).toBe(
+      configProjectId,
+    );
+  });
+
+  test(`should fall-back to the serviceAccount's projectId when ther is no projectId in the config`, () => {
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig: {
+        ...integrationConfig,
+        projectId: 'someId',
+      },
+    });
+    delete context.instance.config.projectId;
+    const configProjectId = context.instance.config.projectId;
+    const serviceAccountProjectId =
+      context.instance.config.serviceAccountKeyConfig.project_id;
+    const mockEntity: Entity = {
+      _key: 'abc',
+      _class: 'Resource',
+      _type: 'type',
+    };
+    expect(configProjectId).toBeFalsy();
+    expect(serviceAccountProjectId).toBeTruthy();
+    expect(maybeDefaultProjectIdOnEntity(context, mockEntity).projectId).toBe(
+      serviceAccountProjectId,
+    );
+  });
+});

--- a/src/utils/maybeDefaultProjectIdOnEntity.ts
+++ b/src/utils/maybeDefaultProjectIdOnEntity.ts
@@ -1,0 +1,30 @@
+import { Entity } from '@jupiterone/integration-sdk-core';
+import { bindingEntities } from '../steps/cloud-asset/constants';
+import {
+  ORGANIZATION_ENTITY_TYPE,
+  FOLDER_ENTITY_TYPE,
+} from '../steps/resource-manager';
+
+/**
+ * Defaults the projectId on an entity if the entity exists within a project.
+ */
+export function maybeDefaultProjectIdOnEntity(context, entity: Entity): Entity {
+  // Do not put the project on organizations, folders, and bindings as they can live outside of a project.
+  if (
+    [
+      ORGANIZATION_ENTITY_TYPE,
+      FOLDER_ENTITY_TYPE,
+      bindingEntities.BINDINGS._type,
+    ].includes(entity._type)
+  ) {
+    return entity;
+  }
+  // Otherwise, default the projectId on every entity.
+  return {
+    ...entity,
+    projectId:
+      entity.projectId ??
+      context.instance.config.projectId ??
+      context.instance.config.serviceAccountKeyConfig.project_id,
+  };
+}


### PR DESCRIPTION
This has caused confusion when using projectId to search off of. A more permeant solution for this might be to go into every converter and manually add the projectId. I opted not to do that in this PR in order to maintain a light-touch, but it would be more clear if we switched to that method.