### PR TITLE
Store rawData on google_iam_bindings again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Added
+
+- `rawData` will now be stored for `google_iam_binding`s.
+
 ## 2.5.0 - 2021-12-06
 
 ### Added

--- a/src/steps/cloud-asset/__snapshots__/converters.test.ts.snap
+++ b/src/steps/cloud-asset/__snapshots__/converters.test.ts.snap
@@ -6,7 +6,22 @@ Object {
     "AccessPolicy",
   ],
   "_key": "binding|project:projects/123456789|resource:resource|role:projects/j1-gc-integration-dev-v3/roles/167984947943customroleconditions|members:d67596848eadce677215c99cb8d085373e61df54|condition:resource.name != \\"bogusunknownresourcename\\"",
-  "_rawData": Array [],
+  "_rawData": Array [
+    Object {
+      "name": "default",
+      "rawData": Object {
+        "condition": Object {
+          "description": "Test condition description",
+          "expression": "resource.name != \\"bogusunknownresourcename\\"",
+          "title": "Test condition title",
+        },
+        "members": Array [
+          "serviceAccount:j1-gc-integration-dev-sa-tf@j1-gc-integration-dev-v3.iam.gserviceaccount.com",
+        ],
+        "role": "projects/j1-gc-integration-dev-v3/roles/167984947943customroleconditions",
+      },
+    },
+  ],
   "_type": "google_iam_binding",
   "condition.description": "Test condition description",
   "condition.expression": "resource.name != \\"bogusunknownresourcename\\"",

--- a/src/steps/cloud-asset/converters.ts
+++ b/src/steps/cloud-asset/converters.ts
@@ -69,7 +69,7 @@ export function createIamBindingEntity({
 
   return createGoogleCloudIntegrationEntity(binding, {
     entityData: {
-      source: {}, // rawData was removed to prevent `Request must be smaller than 6291456 bytes for the InvokeFunction operation` errors
+      source: binding,
       assign: {
         _class: bindingEntities.BINDINGS._class,
         _type: bindingEntities.BINDINGS._type,

--- a/src/steps/compute/__snapshots__/index.test.ts.snap
+++ b/src/steps/compute/__snapshots__/index.test.ts.snap
@@ -16621,7 +16621,7 @@ Object {
       "_class": Array [
         "Image",
       ],
-      "_key": undefined,
+      "_key": "j1-gc-integration-dev-v3:example-snapshot-image:deleted",
       "_rawData": Array [
         Object {
           "name": "default",
@@ -17209,8 +17209,8 @@ Object {
     Object {
       "_class": "USES",
       "_fromEntityKey": "disk:3169341475684659331",
-      "_key": "disk:3169341475684659331|uses|undefined",
-      "_toEntityKey": undefined,
+      "_key": "disk:3169341475684659331|uses|j1-gc-integration-dev-v3:example-snapshot-image:deleted",
+      "_toEntityKey": "j1-gc-integration-dev-v3:example-snapshot-image:deleted",
       "_type": "google_compute_disk_uses_image",
       "displayName": "USES",
     },


### PR DESCRIPTION
This was originally taken out because it was assumed that this was causing a RequestTooLarge exception. This was not the issue and can thus be safely be re-added. Plus, the rawData for bindings is actually really small. Example:

```
      "_rawData": [
        {
          "name": "default",
          "rawData": {
            "role": "roles/cloudkms.serviceAgent",
            "members": [
              "serviceAccount:service-167984947943@gcp-sa-cloudkms.iam.gserviceaccount.com"
            ]
          }
        }
      ]
```