### PR TITLE
Index binding relationship metadata again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Added
+
+- Metadata indexing of `google_iam_binding` relationships.
+
 ## 2.5.2 - 2021-12-06
 
 ### Added

--- a/src/steps/cloud-asset/constants.ts
+++ b/src/steps/cloud-asset/constants.ts
@@ -54,9 +54,6 @@ export const BINDING_ASSIGNED_PRINCIPAL_RELATIONSHIPS = IAM_PRINCIPAL_TYPES.map(
       sourceType: bindingEntities.BINDINGS._type,
       _class: RelationshipClass.ASSIGNED,
       targetType: principalType,
-      indexMetadata: {
-        enabled: false,
-      },
     };
   },
 );
@@ -75,9 +72,6 @@ export const BINDING_ALLOWS_ANY_RESOURCE_RELATIONSHIP = {
   ),
   sourceType: bindingEntities.BINDINGS._type,
   targetType: ANY_RESOURCE,
-  indexMetadata: {
-    enabled: false,
-  },
 };
 
 export const API_SERVICE_HAS_ANY_RESOURCE_RELATIONSHIP = {
@@ -90,7 +84,4 @@ export const API_SERVICE_HAS_ANY_RESOURCE_RELATIONSHIP = {
   ),
   sourceType: API_SERVICE_ENTITY_TYPE,
   targetType: ANY_RESOURCE,
-  indexMetadata: {
-    enabled: false,
-  },
 };

--- a/src/steps/cloud-asset/index.ts
+++ b/src/steps/cloud-asset/index.ts
@@ -837,9 +837,6 @@ export const cloudAssetSteps: IntegrationStep<IntegrationConfig>[] = [
         ),
         sourceType: bindingEntities.BINDINGS._type,
         targetType: IAM_ROLE_ENTITY_TYPE,
-        indexMetadata: {
-          enabled: false,
-        },
       },
     ],
     dependsOn: [STEP_IAM_BINDINGS, STEP_CREATE_BASIC_ROLES],


### PR DESCRIPTION
This was originally done because we believed that `google_iam_binding`s were too large to be uploaded via lambda. This turned out not to be the case, so it is safe to index again. 

The reason why we need to index this data again is because I believe it is causing relationships to be skipped (and thus deleted) in very small integrations. I haven't been able to reproduce this yet, but there does seem like there could be a race-condition problem with the non-indexed uploads.