### PR TITLE
Add better BigQuery model key

### DIFF
--- a/src/steps/big-query/__recordings__/fetchBigQueryModels_1144670279/recording.har
+++ b/src/steps/big-query/__recordings__/fetchBigQueryModels_1144670279/recording.har
@@ -62,10 +62,10 @@
           "url": "https://www.googleapis.com/oauth2/v4/token"
         },
         "response": {
-          "bodySize": 560,
+          "bodySize": 566,
           "content": {
             "mimeType": "application/json; charset=UTF-8",
-            "size": 560,
+            "size": 566,
             "text": "{\"access_token\":\"[REDACTED]\",\"expires_in\":9999,\"token_type\":\"Bearer\"}"
           },
           "cookies": [],
@@ -80,7 +80,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 18 Aug 2021 13:26:08 GMT"
+              "value": "Tue, 07 Dec 2021 23:27:48 GMT"
             },
             {
               "name": "server",
@@ -104,21 +104,21 @@
             },
             {
               "name": "alt-svc",
-              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 533,
+          "headersSize": 506,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-18T13:26:07.847Z",
-        "time": 186,
+        "startedDateTime": "2021-12-07T23:27:48.136Z",
+        "time": 159,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -126,7 +126,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 186
+          "wait": 159
         }
       },
       {
@@ -140,7 +140,7 @@
             {
               "_fromType": "array",
               "name": "x-goog-api-client",
-              "value": "gdcl/5.0.2 gl-node/14.15.4 auth/7.1.1"
+              "value": "gdcl/5.0.2 gl-node/14.18.2 auth/7.1.1"
             },
             {
               "_fromType": "array",
@@ -172,17 +172,17 @@
               "value": "bigquery.googleapis.com"
             }
           ],
-          "headersSize": 1325,
+          "headersSize": 567,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
           "url": "https://bigquery.googleapis.com/bigquery/v2/projects/j1-gc-integration-dev-v3/datasets"
         },
         "response": {
-          "bodySize": 543,
+          "bodySize": 558,
           "content": {
             "mimeType": "application/json; charset=UTF-8",
-            "size": 543,
+            "size": 558,
             "text": "{\"kind\":\"bigquery#datasetList\",\"etag\":\"nwGZDGePfb7xz8MC8+MgKQ==\",\"datasets\":[{\"kind\":\"bigquery#dataset\",\"id\":\"j1-gc-integration-dev-v3:cmed_example_dataset\",\"datasetReference\":{\"datasetId\":\"cmed_example_dataset\",\"projectId\":\"j1-gc-integration-dev-v3\"},\"friendlyName\":\"cmed_example_dataset\",\"location\":\"US\"},{\"kind\":\"bigquery#dataset\",\"id\":\"j1-gc-integration-dev-v3:natality\",\"datasetReference\":{\"datasetId\":\"natality\",\"projectId\":\"j1-gc-integration-dev-v3\"},\"location\":\"US\"},{\"kind\":\"bigquery#dataset\",\"id\":\"j1-gc-integration-dev-v3:test_big_query_dataset\",\"datasetReference\":{\"datasetId\":\"test_big_query_dataset\",\"projectId\":\"j1-gc-integration-dev-v3\"},\"location\":\"US\"}]}"
           },
           "cookies": [],
@@ -201,7 +201,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 18 Aug 2021 13:26:08 GMT"
+              "value": "Tue, 07 Dec 2021 23:27:48 GMT"
             },
             {
               "name": "server",
@@ -225,21 +225,21 @@
             },
             {
               "name": "alt-svc",
-              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 542,
+          "headersSize": 515,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-18T13:26:08.062Z",
-        "time": 504,
+        "startedDateTime": "2021-12-07T23:27:48.309Z",
+        "time": 365,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -247,7 +247,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 504
+          "wait": 365
         }
       },
       {
@@ -261,7 +261,7 @@
             {
               "_fromType": "array",
               "name": "x-goog-api-client",
-              "value": "gdcl/5.0.2 gl-node/14.15.4 auth/7.1.1"
+              "value": "gdcl/5.0.2 gl-node/14.18.2 auth/7.1.1"
             },
             {
               "_fromType": "array",
@@ -293,17 +293,17 @@
               "value": "bigquery.googleapis.com"
             }
           ],
-          "headersSize": 1346,
+          "headersSize": 588,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
           "url": "https://bigquery.googleapis.com/bigquery/v2/projects/j1-gc-integration-dev-v3/datasets/cmed_example_dataset"
         },
         "response": {
-          "bodySize": 1059,
+          "bodySize": 1029,
           "content": {
             "mimeType": "application/json; charset=UTF-8",
-            "size": 1059,
+            "size": 1029,
             "text": "{\"kind\":\"bigquery#dataset\",\"etag\":\"6b722DsKHYaa6CwPpa8AsA==\",\"id\":\"j1-gc-integration-dev-v3:cmed_example_dataset\",\"selfLink\":\"https://www.googleapis.com/bigquery/v2/projects/j1-gc-integration-dev-v3/datasets/cmed_example_dataset\",\"datasetReference\":{\"datasetId\":\"cmed_example_dataset\",\"projectId\":\"j1-gc-integration-dev-v3\"},\"friendlyName\":\"cmed_example_dataset\",\"description\":\"This is a test description\",\"defaultTableExpirationMs\":\"3600000\",\"access\":[{\"role\":\"WRITER\",\"specialGroup\":\"projectWriters\"},{\"role\":\"OWNER\",\"specialGroup\":\"projectOwners\"},{\"role\":\"OWNER\",\"userByEmail\":\"j1-gc-integration-dev-sa-tf@j1-gc-integration-dev-v3.iam.gserviceaccount.com\"},{\"role\":\"READER\",\"specialGroup\":\"projectReaders\"}],\"creationTime\":\"1622479211545\",\"lastModifiedTime\":\"1622479211545\",\"location\":\"US\",\"defaultEncryptionConfiguration\":{\"kmsKeyName\":\"projects/j1-gc-integration-dev-v3/locations/us/keyRings/example-keyring/cryptoKeys/cmek_bigquery_crypto_key\"},\"type\":\"DEFAULT\"}"
           },
           "cookies": [],
@@ -322,7 +322,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 18 Aug 2021 13:26:08 GMT"
+              "value": "Tue, 07 Dec 2021 23:27:49 GMT"
             },
             {
               "name": "server",
@@ -346,21 +346,21 @@
             },
             {
               "name": "alt-svc",
-              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 542,
+          "headersSize": 515,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-18T13:26:08.572Z",
-        "time": 429,
+        "startedDateTime": "2021-12-07T23:27:48.681Z",
+        "time": 413,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -368,7 +368,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 429
+          "wait": 413
         }
       },
       {
@@ -382,7 +382,7 @@
             {
               "_fromType": "array",
               "name": "x-goog-api-client",
-              "value": "gdcl/5.0.2 gl-node/14.15.4 auth/7.1.1"
+              "value": "gdcl/5.0.2 gl-node/14.18.2 auth/7.1.1"
             },
             {
               "_fromType": "array",
@@ -414,17 +414,17 @@
               "value": "bigquery.googleapis.com"
             }
           ],
-          "headersSize": 1334,
+          "headersSize": 576,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
           "url": "https://bigquery.googleapis.com/bigquery/v2/projects/j1-gc-integration-dev-v3/datasets/natality"
         },
         "response": {
-          "bodySize": 766,
+          "bodySize": 778,
           "content": {
             "mimeType": "application/json; charset=UTF-8",
-            "size": 766,
+            "size": 778,
             "text": "{\"kind\":\"bigquery#dataset\",\"etag\":\"3HvFpmbEqtGpoaRb98i5ZQ==\",\"id\":\"j1-gc-integration-dev-v3:natality\",\"selfLink\":\"https://www.googleapis.com/bigquery/v2/projects/j1-gc-integration-dev-v3/datasets/natality\",\"datasetReference\":{\"datasetId\":\"natality\",\"projectId\":\"j1-gc-integration-dev-v3\"},\"access\":[{\"role\":\"WRITER\",\"specialGroup\":\"projectWriters\"},{\"role\":\"OWNER\",\"specialGroup\":\"projectOwners\"},{\"role\":\"OWNER\",\"userByEmail\":\"viragsf@gmail.com\"},{\"role\":\"READER\",\"specialGroup\":\"projectReaders\"}],\"creationTime\":\"1622550833239\",\"lastModifiedTime\":\"1622550833239\",\"location\":\"US\",\"type\":\"DEFAULT\"}"
           },
           "cookies": [],
@@ -443,7 +443,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 18 Aug 2021 13:26:09 GMT"
+              "value": "Tue, 07 Dec 2021 23:27:49 GMT"
             },
             {
               "name": "server",
@@ -467,21 +467,21 @@
             },
             {
               "name": "alt-svc",
-              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 542,
+          "headersSize": 515,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-18T13:26:09.099Z",
-        "time": 599,
+        "startedDateTime": "2021-12-07T23:27:49.163Z",
+        "time": 532,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -489,7 +489,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 599
+          "wait": 532
         }
       },
       {
@@ -503,7 +503,7 @@
             {
               "_fromType": "array",
               "name": "x-goog-api-client",
-              "value": "gdcl/5.0.2 gl-node/14.15.4 auth/7.1.1"
+              "value": "gdcl/5.0.2 gl-node/14.18.2 auth/7.1.1"
             },
             {
               "_fromType": "array",
@@ -535,17 +535,17 @@
               "value": "bigquery.googleapis.com"
             }
           ],
-          "headersSize": 1348,
+          "headersSize": 590,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
           "url": "https://bigquery.googleapis.com/bigquery/v2/projects/j1-gc-integration-dev-v3/datasets/test_big_query_dataset"
         },
         "response": {
-          "bodySize": 753,
+          "bodySize": 768,
           "content": {
             "mimeType": "application/json; charset=UTF-8",
-            "size": 753,
+            "size": 768,
             "text": "{\"kind\":\"bigquery#dataset\",\"etag\":\"JwXL1gHmp026gU7mTnb1wQ==\",\"id\":\"j1-gc-integration-dev-v3:test_big_query_dataset\",\"selfLink\":\"https://www.googleapis.com/bigquery/v2/projects/j1-gc-integration-dev-v3/datasets/test_big_query_dataset\",\"datasetReference\":{\"datasetId\":\"test_big_query_dataset\",\"projectId\":\"j1-gc-integration-dev-v3\"},\"description\":\"This is a test description\",\"access\":[{\"role\":\"OWNER\",\"userByEmail\":\"j1-gc-integration-dev-sa-tf@j1-gc-integration-dev-v3.iam.gserviceaccount.com\"}],\"creationTime\":\"1622478350061\",\"lastModifiedTime\":\"1628272655532\",\"location\":\"US\",\"type\":\"DEFAULT\"}"
           },
           "cookies": [],
@@ -564,7 +564,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 18 Aug 2021 13:26:10 GMT"
+              "value": "Tue, 07 Dec 2021 23:27:50 GMT"
             },
             {
               "name": "server",
@@ -588,21 +588,21 @@
             },
             {
               "name": "alt-svc",
-              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 542,
+          "headersSize": 515,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-18T13:26:09.703Z",
-        "time": 593,
+        "startedDateTime": "2021-12-07T23:27:49.701Z",
+        "time": 496,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -610,7 +610,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 593
+          "wait": 496
         }
       },
       {
@@ -668,10 +668,10 @@
           "url": "https://www.googleapis.com/oauth2/v4/token"
         },
         "response": {
-          "bodySize": 559,
+          "bodySize": 594,
           "content": {
             "mimeType": "application/json; charset=UTF-8",
-            "size": 559,
+            "size": 594,
             "text": "{\"access_token\":\"[REDACTED]\",\"expires_in\":9999,\"token_type\":\"Bearer\"}"
           },
           "cookies": [],
@@ -686,7 +686,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 18 Aug 2021 13:26:10 GMT"
+              "value": "Tue, 07 Dec 2021 23:27:50 GMT"
             },
             {
               "name": "server",
@@ -710,21 +710,21 @@
             },
             {
               "name": "alt-svc",
-              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 533,
+          "headersSize": 506,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-18T13:26:10.307Z",
-        "time": 132,
+        "startedDateTime": "2021-12-07T23:27:50.231Z",
+        "time": 97,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -732,7 +732,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 132
+          "wait": 97
         }
       },
       {
@@ -746,7 +746,7 @@
             {
               "_fromType": "array",
               "name": "x-goog-api-client",
-              "value": "gdcl/5.0.2 gl-node/14.15.4 auth/7.1.1"
+              "value": "gdcl/5.0.2 gl-node/14.18.2 auth/7.1.1"
             },
             {
               "_fromType": "array",
@@ -785,10 +785,10 @@
           "url": "https://bigquery.googleapis.com/bigquery/v2/projects/j1-gc-integration-dev-v3/datasets/cmed_example_dataset/models"
         },
         "response": {
-          "bodySize": 53,
+          "bodySize": 95,
           "content": {
             "mimeType": "application/json; charset=UTF-8",
-            "size": 53,
+            "size": 95,
             "text": "{}"
           },
           "cookies": [],
@@ -803,7 +803,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 18 Aug 2021 13:26:10 GMT"
+              "value": "Tue, 07 Dec 2021 23:27:50 GMT"
             },
             {
               "name": "server",
@@ -827,21 +827,21 @@
             },
             {
               "name": "alt-svc",
-              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 510,
+          "headersSize": 483,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-18T13:26:10.445Z",
-        "time": 492,
+        "startedDateTime": "2021-12-07T23:27:50.333Z",
+        "time": 453,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -849,7 +849,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 492
+          "wait": 453
         }
       },
       {
@@ -863,7 +863,7 @@
             {
               "_fromType": "array",
               "name": "x-goog-api-client",
-              "value": "gdcl/5.0.2 gl-node/14.15.4 auth/7.1.1"
+              "value": "gdcl/5.0.2 gl-node/14.18.2 auth/7.1.1"
             },
             {
               "_fromType": "array",
@@ -902,10 +902,10 @@
           "url": "https://bigquery.googleapis.com/bigquery/v2/projects/j1-gc-integration-dev-v3/datasets/natality/models"
         },
         "response": {
-          "bodySize": 435,
+          "bodySize": 432,
           "content": {
             "mimeType": "application/json; charset=UTF-8",
-            "size": 435,
+            "size": 432,
             "text": "{\"models\":[{\"modelReference\":{\"projectId\":\"j1-gc-integration-dev-v3\",\"datasetId\":\"natality\",\"modelId\":\"natality_model\"},\"creationTime\":\"1622550868545\",\"lastModifiedTime\":\"1622550868626\",\"modelType\":\"LINEAR_REGRESSION\"}]}"
           },
           "cookies": [],
@@ -920,7 +920,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 18 Aug 2021 13:26:11 GMT"
+              "value": "Tue, 07 Dec 2021 23:27:51 GMT"
             },
             {
               "name": "server",
@@ -944,21 +944,21 @@
             },
             {
               "name": "alt-svc",
-              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 510,
+          "headersSize": 483,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-18T13:26:10.943Z",
-        "time": 497,
+        "startedDateTime": "2021-12-07T23:27:50.794Z",
+        "time": 401,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -966,7 +966,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 497
+          "wait": 401
         }
       },
       {
@@ -980,7 +980,7 @@
             {
               "_fromType": "array",
               "name": "x-goog-api-client",
-              "value": "gdcl/5.0.2 gl-node/14.15.4 auth/7.1.1"
+              "value": "gdcl/5.0.2 gl-node/14.18.2 auth/7.1.1"
             },
             {
               "_fromType": "array",
@@ -1019,10 +1019,10 @@
           "url": "https://bigquery.googleapis.com/bigquery/v2/projects/j1-gc-integration-dev-v3/datasets/natality/models/natality_model"
         },
         "response": {
-          "bodySize": 1630,
+          "bodySize": 1606,
           "content": {
             "mimeType": "application/json; charset=UTF-8",
-            "size": 1630,
+            "size": 1606,
             "text": "{\"etag\":\"TqdFEafie4P/uCkcTDeDoQ==\",\"modelReference\":{\"projectId\":\"j1-gc-integration-dev-v3\",\"datasetId\":\"natality\",\"modelId\":\"natality_model\"},\"creationTime\":\"1622550868545\",\"lastModifiedTime\":\"1622550868626\",\"modelType\":\"LINEAR_REGRESSION\",\"trainingRuns\":[{\"trainingOptions\":{\"lossType\":\"MEAN_SQUARED_LOSS\",\"l2Regularization\":0,\"optimizationStrategy\":\"NORMAL_EQUATION\"},\"results\":[{\"index\":0,\"durationMs\":\"4380\",\"trainingLoss\":1.6786873767108144,\"evalLoss\":1.6561986053104691}],\"evaluationMetrics\":{\"regressionMetrics\":{\"meanAbsoluteError\":0.9538477406705936,\"meanSquaredError\":1.6561986053104583,\"meanSquaredLogError\":0.03441221912886547,\"medianAbsoluteError\":0.7463386416288529,\"rSquared\":0.042719525606098596}},\"startTime\":\"2021-06-01T12:34:11.714Z\",\"dataSplitResult\":{\"trainingTable\":{\"projectId\":\"j1-gc-integration-dev-v3\",\"datasetId\":\"_dc91ff9c66b0b00709a1245f8bd9d5ddbfdf7aea\",\"tableId\":\"anon0bba0136_499d_4347_a2fc_b490d93dfe6a_imported_data_split_training_data\"},\"evaluationTable\":{\"projectId\":\"j1-gc-integration-dev-v3\",\"datasetId\":\"_dc91ff9c66b0b00709a1245f8bd9d5ddbfdf7aea\",\"tableId\":\"anon0bba0136_499d_4347_a2fc_b490d93dfe6a_imported_data_split_eval_data\"}}}],\"featureColumns\":[{\"name\":\"is_male\",\"type\":{\"typeKind\":\"BOOL\"}},{\"name\":\"gestation_weeks\",\"type\":{\"typeKind\":\"INT64\"}},{\"name\":\"mother_age\",\"type\":{\"typeKind\":\"INT64\"}},{\"name\":\"mother_race\",\"type\":{\"typeKind\":\"STRING\"}}],\"labelColumns\":[{\"name\":\"predicted_weight_pounds\",\"type\":{\"typeKind\":\"FLOAT64\"}}],\"location\":\"US\"}"
           },
           "cookies": [],
@@ -1037,7 +1037,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 18 Aug 2021 13:26:11 GMT"
+              "value": "Tue, 07 Dec 2021 23:27:51 GMT"
             },
             {
               "name": "server",
@@ -1061,21 +1061,21 @@
             },
             {
               "name": "alt-svc",
-              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 510,
+          "headersSize": 483,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-18T13:26:11.448Z",
-        "time": 490,
+        "startedDateTime": "2021-12-07T23:27:51.200Z",
+        "time": 422,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1083,7 +1083,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 490
+          "wait": 422
         }
       },
       {
@@ -1097,7 +1097,7 @@
             {
               "_fromType": "array",
               "name": "x-goog-api-client",
-              "value": "gdcl/5.0.2 gl-node/14.15.4 auth/7.1.1"
+              "value": "gdcl/5.0.2 gl-node/14.18.2 auth/7.1.1"
             },
             {
               "_fromType": "array",
@@ -1136,10 +1136,10 @@
           "url": "https://bigquery.googleapis.com/bigquery/v2/projects/j1-gc-integration-dev-v3/datasets/test_big_query_dataset/models"
         },
         "response": {
-          "bodySize": 71,
+          "bodySize": 83,
           "content": {
             "mimeType": "application/json; charset=UTF-8",
-            "size": 71,
+            "size": 83,
             "text": "{}"
           },
           "cookies": [],
@@ -1154,7 +1154,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 18 Aug 2021 13:26:12 GMT"
+              "value": "Tue, 07 Dec 2021 23:27:52 GMT"
             },
             {
               "name": "server",
@@ -1178,21 +1178,21 @@
             },
             {
               "name": "alt-svc",
-              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 510,
+          "headersSize": 483,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-18T13:26:11.946Z",
-        "time": 503,
+        "startedDateTime": "2021-12-07T23:27:51.647Z",
+        "time": 405,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1200,7 +1200,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 503
+          "wait": 405
         }
       }
     ],

--- a/src/steps/big-query/__snapshots__/converters.test.ts.snap
+++ b/src/steps/big-query/__snapshots__/converters.test.ts.snap
@@ -133,7 +133,7 @@ Object {
   "_class": Array [
     "Model",
   ],
-  "_key": "natality_model",
+  "_key": "j1-gc-integration-dev-v2:test_big_query_dataset:natality_model",
   "_rawData": Array [
     Object {
       "name": "default",

--- a/src/steps/big-query/__snapshots__/index.test.ts.snap
+++ b/src/steps/big-query/__snapshots__/index.test.ts.snap
@@ -358,7 +358,7 @@ Object {
       "_class": Array [
         "Model",
       ],
-      "_key": "natality_model",
+      "_key": "j1-gc-integration-dev-v3:natality:natality_model",
       "_rawData": Array [
         Object {
           "name": "default",
@@ -467,8 +467,8 @@ Object {
     Object {
       "_class": "HAS",
       "_fromEntityKey": "j1-gc-integration-dev-v3:natality",
-      "_key": "j1-gc-integration-dev-v3:natality|has|natality_model",
-      "_toEntityKey": "natality_model",
+      "_key": "j1-gc-integration-dev-v3:natality|has|j1-gc-integration-dev-v3:natality:natality_model",
+      "_toEntityKey": "j1-gc-integration-dev-v3:natality:natality_model",
       "_type": "google_bigquery_dataset_has_model",
       "displayName": "HAS",
     },

--- a/src/steps/big-query/converters.test.ts
+++ b/src/steps/big-query/converters.test.ts
@@ -37,7 +37,12 @@ describe('#createBigQueryDatasetEntity', () => {
 
 describe('#createBigQueryModelEntity', () => {
   test('should convert to entity', () => {
-    expect(createBigQueryModelEntity(getMockBigQueryModel())).toMatchSnapshot();
+    expect(
+      createBigQueryModelEntity(
+        getMockBigQueryModel(),
+        'j1-gc-integration-dev-v2:test_big_query_dataset',
+      ),
+    ).toMatchSnapshot();
   });
 });
 

--- a/src/steps/big-query/converters.ts
+++ b/src/steps/big-query/converters.ts
@@ -69,12 +69,22 @@ export function createBigQueryDatasetEntity(data: bigquery_v2.Schema$Dataset) {
   });
 }
 
-export function createBigQueryModelEntity(data: bigquery_v2.Schema$Model) {
+function getBigQueryModelKey(datasetId: string, modelId: string) {
+  return `${datasetId}:${modelId}`;
+}
+
+export function createBigQueryModelEntity(
+  data: bigquery_v2.Schema$Model,
+  datasetId: string,
+) {
   return createGoogleCloudIntegrationEntity(data, {
     entityData: {
       source: data,
       assign: {
-        _key: data.modelReference?.modelId as string,
+        _key: getBigQueryModelKey(
+          datasetId,
+          data.modelReference?.modelId as string,
+        ),
         _type: BIG_QUERY_MODEL_ENTITY_TYPE,
         _class: BIG_QUERY_MODEL_ENTITY_CLASS,
         name: data.modelReference?.modelId,

--- a/src/steps/big-query/index.ts
+++ b/src/steps/big-query/index.ts
@@ -131,7 +131,10 @@ export async function fetchBigQueryModels(
         await client.iterateBigQueryModels(
           datasetEntity.name as string,
           async (model) => {
-            const modelEntity = createBigQueryModelEntity(model);
+            const modelEntity = createBigQueryModelEntity(
+              model,
+              datasetEntity.id as string,
+            );
             await jobState.addEntity(modelEntity);
 
             await jobState.addRelationship(

--- a/src/steps/compute/__snapshots__/index.test.ts.snap
+++ b/src/steps/compute/__snapshots__/index.test.ts.snap
@@ -16621,7 +16621,7 @@ Object {
       "_class": Array [
         "Image",
       ],
-      "_key": undefined,
+      "_key": "j1-gc-integration-dev-v3:example-snapshot-image:deleted",
       "_rawData": Array [
         Object {
           "name": "default",
@@ -17209,8 +17209,8 @@ Object {
     Object {
       "_class": "USES",
       "_fromEntityKey": "disk:3169341475684659331",
-      "_key": "disk:3169341475684659331|uses|undefined",
-      "_toEntityKey": undefined,
+      "_key": "disk:3169341475684659331|uses|j1-gc-integration-dev-v3:example-snapshot-image:deleted",
+      "_toEntityKey": "j1-gc-integration-dev-v3:example-snapshot-image:deleted",
       "_type": "google_compute_disk_uses_image",
       "displayName": "USES",
     },


### PR DESCRIPTION
This is a fix for an error reported by the Sentry (https://sentry.io/organizations/jupiterone/issues/2523219247/events/1be64ee5742e486eae980274f3fd71b6/?project=5871712&statsPeriod=14d).

This stemmed from the very basic BigQuery model key we were using before. The BigQuery datasets have a key of this format `j1-gc-integration-dev-v3:natality`, I've gone ahead and modified the model's keys to follow the same pattern, just with modelId appended at the end, e.g. `j1-gc-integration-dev-v3:natality:natality_model`.

Edit: need to modify converters.test.ts slightly for this change, doing that right now.
Edit 2: done.

P.S I'm not yet sure how to properly document these: Sentry/AWS Cloudwatch -> PR -> resolution. I'm guessing I should also create a Jira ticket for this, and somehow match the titles/ids/references. I'll start doing that properly moving forward as soon as I figure out/learn the workflow. :slightly_smiling_face: 