### PR TITLE
Always check the jobState when making google_iam_binding relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+
+- When making `google_iam_binding_allows_resource` relationships, we no longer
+  check the if a service is enabled when determining if the relationship should
+  be mapped or direct. This is because for non-organization integration
+  instances, the Resource Manager API does not need to be enabled to ingest a
+  `google_cloud_project`.
+
 ## 2.5.3 - 2021-12-06
 
 ### Added

--- a/src/steps/cloud-asset/index.ts
+++ b/src/steps/cloud-asset/index.ts
@@ -48,7 +48,6 @@ import {
   getTypeAndKeyFromResourceIdentifier,
   makeLogsForTypeAndKeyResponse,
 } from '../../utils/iamBindings/getTypeAndKeyFromResourceIdentifier';
-import { getEnabledServiceNames } from '../enablement';
 import { createIamRoleEntity } from '../iam/converters';
 import {
   basicRoles,
@@ -612,15 +611,10 @@ export async function createPrincipalRelationships(
   );
 }
 
-function getServiceFromResourceIdentifier(googleResourceIdentifier: string) {
-  const [_, __, service, ..._rest] = googleResourceIdentifier.split('/');
-  return service;
-}
-
 export async function createBindingToAnyResourceRelationships(
   context: IntegrationStepContext,
 ): Promise<void> {
-  const { jobState, instance, logger } = context;
+  const { jobState, logger } = context;
   const relationshipKeys = new Set<string>();
 
   async function safeAddRelationship(relationship?: Relationship) {
@@ -630,9 +624,6 @@ export async function createBindingToAnyResourceRelationships(
     }
   }
 
-  const enabledServiceNames =
-    (await getEnabledServiceNames(instance.config))
-      .intersectedEnabledServices ?? [];
   await jobState.iterateEntities(
     { _type: bindingEntities.BINDINGS._type },
     async (bindingEntity: BindingEntity) => {
@@ -645,11 +636,9 @@ export async function createBindingToAnyResourceRelationships(
           ),
         ) ?? {};
       if (typeof key !== 'string') return;
-      // Check to see if service is enabled prior to searching the jobState for an entity
-      const service = getServiceFromResourceIdentifier(bindingEntity.resource);
-      const existingEntity = enabledServiceNames.includes(service)
-        ? await jobState.findEntity(key)
-        : undefined;
+
+      const existingEntity = await jobState.findEntity(key);
+
       const relationship = existingEntity
         ? createDirectRelationship({
             from: bindingEntity,


### PR DESCRIPTION
When making `google_iam_binding_allows_resource` relationships, we no longer check the if a service is enabled when determining if the relationship should be mapped or direct. This is because for non-organization integration instances, the Resource Manager API does not need to be enabled to ingest a `google_cloud_project`, so we would incorrectly make a mapped relationship when it should have been direct. This was added as an optimization that does not speed up the integration much anyway, so it makes sense to just remove it.