### PR TITLE
Generate Google Big Query Table keys correctly when making `google_iam_binding_allows_resource` relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+
+- `_key`s are now generated properly to allow for mapping `google_iam_binding`s
+  to `google_bigquery_table`s when making `google_iam_binding_allows_resource`
+  relationships.
+
 ## 2.6.0 - 2021-12-07
 
 ### Added

--- a/src/utils/iamBindings/__snapshots__/getTypeAndKeyFromResourceIdentifier.test.ts.snap
+++ b/src/utils/iamBindings/__snapshots__/getTypeAndKeyFromResourceIdentifier.test.ts.snap
@@ -563,7 +563,7 @@ Object {
 exports[`getTypeAndKeyFromResourceIdentifier should find the correct keys for all available resources 71`] = `
 Object {
   "identifier": "//bigquery.googleapis.com/projects/12345/datasets/abcdef12345/tables/abcdef12345",
-  "key": "12345:abcdef12345:abcdef12345",
+  "key": "12345:abcdef12345.abcdef12345",
   "type": "google_bigquery_table",
 }
 `;

--- a/src/utils/iamBindings/getTypeAndKeyFromResourceIdentifier.test.ts
+++ b/src/utils/iamBindings/getTypeAndKeyFromResourceIdentifier.test.ts
@@ -18,6 +18,10 @@ import {
   impossible,
   J1_TYPE_TO_KEY_GENERATOR_MAP,
 } from './typeToKeyGeneratorMap';
+import {
+  BIG_QUERY_DATASET_ENTITY_TYPE,
+  BIG_QUERY_TABLE_ENTITY_TYPE,
+} from '../../steps/big-query';
 
 const jupiterOneTypesWithMappedGoogleResources = Object.keys(
   pickBy(J1_TYPE_TO_KEY_GENERATOR_MAP, (keyMethod) => keyMethod !== impossible),
@@ -45,6 +49,34 @@ describe('getTypeAndKeyFromResourceIdentifier', () => {
     expect(successfullyMappedTypes.sort()).toEqual(
       expect.arrayContaining(jupiterOneTypesWithMappedGoogleResources.sort()),
     );
+  });
+
+  test('`google_bigquery_table`s should have their `_key` generated properly', async () => {
+    const context = createMockStepExecutionContext({
+      instanceConfig: integrationConfig,
+    });
+    const exampleBigQueryTableResourceIdentifier = `//bigquery.googleapis.com/projects/${TEST_PROJECT_ID}/datasets/test_big_query_dataset/tables/Test Table`;
+    const expectedKey = `${TEST_PROJECT_ID}:test_big_query_dataset.Test Table`;
+    const { key, type } = await getTypeAndKeyFromResourceIdentifier(
+      exampleBigQueryTableResourceIdentifier,
+      context,
+    );
+    expect(key).toBe(expectedKey);
+    expect(type).toBe(BIG_QUERY_TABLE_ENTITY_TYPE);
+  });
+
+  test('`google_bigquery_dataset`s should have their `_key` generated properly', async () => {
+    const context = createMockStepExecutionContext({
+      instanceConfig: integrationConfig,
+    });
+    const exampleBigQueryDatasetResourceIdentifier = `//bigquery.googleapis.com/projects/${TEST_PROJECT_ID}/datasets/test_big_query_dataset`;
+    const expectedKey = `${TEST_PROJECT_ID}:test_big_query_dataset`;
+    const { key, type } = await getTypeAndKeyFromResourceIdentifier(
+      exampleBigQueryDatasetResourceIdentifier,
+      context,
+    );
+    expect(key).toBe(expectedKey);
+    expect(type).toBe(BIG_QUERY_DATASET_ENTITY_TYPE);
   });
 });
 

--- a/src/utils/iamBindings/typeToKeyGeneratorMap.ts
+++ b/src/utils/iamBindings/typeToKeyGeneratorMap.ts
@@ -146,8 +146,8 @@ export const J1_TYPE_TO_KEY_GENERATOR_MAP: {
   [DNS_MANAGED_ZONE_ENTITY_TYPE]: finalIdentifierKeyMap,
   [ENTITY_TYPE_SPANNER_INSTANCE]: fullPathKeyMap,
   [ENTITY_TYPE_SPANNER_INSTANCE_DATABASE]: fullPathKeyMap,
-  [BIG_QUERY_DATASET_ENTITY_TYPE]: allUniqueIdentifiers,
-  [BIG_QUERY_TABLE_ENTITY_TYPE]: allUniqueIdentifiers,
+  [BIG_QUERY_DATASET_ENTITY_TYPE]: bigQueryIdentifier,
+  [BIG_QUERY_TABLE_ENTITY_TYPE]: bigQueryIdentifier,
   [IAM_ROLE_ENTITY_TYPE]: impossible, // Key is different depending on if it is a custom or managed Role. I'm pretty sure this can not be the target of a role binding.
   [IAM_SERVICE_ACCOUNT_ENTITY_TYPE]: finalIdentifierKeyMap,
   [IAM_SERVICE_ACCOUNT_KEY_ENTITY_TYPE]: fullPathKeyMap,
@@ -211,39 +211,29 @@ function selfLinkKeyMap(googleResourceIdentifier: string): string {
   );
 }
 
-// ex: j1-gc-integration-dev-v3
-// ex: j1-gc-integration-dev-v3:test_big_query_dataset
-// ex: j1-gc-integration-dev-v3:natality.Test Table
-function allUniqueIdentifiers(googleResourceIdentifier: string): string {
-  const [
-    _,
-    __,
-    _service,
-    _firstDivision,
-    idForFistDivision,
-    _secondDivision,
-    idForSecondDivision,
-    _thirdDivision,
-    idForThirdDivision,
-    _fourthDivision,
-    idForFourthDivision,
-  ] = googleResourceIdentifier.split('/');
-  return [
-    idForFistDivision,
-    idForSecondDivision,
-    idForThirdDivision,
-    idForFourthDivision,
-  ]
-    .filter((i) => !!i)
-    .join(':');
-}
-
 // ex: cloudrun_service:2fab1cb9-fb5c-4f22-b364-979cebdc2820
 function customPrefixAndIdKeyMap(
   customKeyPrefixFunction: (uid: string) => string,
 ): (googleResourceIdentifier: string) => string {
   return (googleResourceIdentifier: string) =>
     customKeyPrefixFunction(finalIdentifierKeyMap(googleResourceIdentifier));
+}
+
+// ex: DATASET - j1-gc-integration-dev-v3:test_big_query_dataset
+// ex: TABLE   - j1-gc-integration-dev-v3:test_big_query_dataset.Test Table
+function bigQueryIdentifier(googleResourceIdentifier: string): string {
+  const [
+    _,
+    __,
+    _service,
+    _literallyTheWordProjects,
+    project,
+    _literallyTheWordDatasets,
+    dataset,
+    _literallyTheWordTables,
+    table,
+  ] = googleResourceIdentifier.split('/');
+  return project + ':' + dataset + (table ? '.' + table : '');
 }
 
 // Used when there is no way to generate the J1 entity key given only the googleResourceIdentifier


### PR DESCRIPTION
`google_iam_binding` => `google_bigquery_table` relationships were not getting created because the `_key` that is used when creating the relationship was getting generated like:

`j1-gc-integration-dev-v3:test_big_query_dataset:Test Table` instead of
`j1-gc-integration-dev-v3:test_big_query_dataset.Test Table`

If you squint, you can notice the `:` instead of `.` before "Test Table".