### PR TITLE
Allow forks to execute questions file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,6 @@ jobs:
         run: yarn
 
       - name: Run tests
-        env:
-          JUPITERONE_ACCOUNT_ID: ${{ secrets.MANAGED_QUESTIONS_JUPITERONE_ACCOUNT_ID }}
-          JUPITERONE_API_KEY: ${{ secrets.MANAGED_QUESTIONS_JUPITERONE_API_KEY }}
         run: yarn test:ci
 
       - name: Run build

--- a/.github/workflows/questions.yml
+++ b/.github/workflows/questions.yml
@@ -1,0 +1,38 @@
+name: Questions
+on: [pull_request_target]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: setup-node
+        name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+
+      - name: Check out `main` branch
+        uses: actions/checkout@v2
+        with: 
+          path: source
+      
+      - name: Check out target branch questions
+        uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          path: target
+
+      - name: Install dependencies for `main` branch
+        run: yarn install --cwd source
+
+      - name: Validate questions on target branch
+        env:
+          MANAGED_QUESTIONS_JUPITERONE_ACCOUNT_ID: ${{ secrets.MANAGED_QUESTIONS_JUPITERONE_ACCOUNT_ID }}
+          MANAGED_QUESTIONS_JUPITERONE_API_KEY: ${{ secrets.MANAGED_QUESTIONS_JUPITERONE_API_KEY }}
+        run: yarn --cwd source 
+               j1-integration validate-question-file 
+                 -a $MANAGED_QUESTIONS_JUPITERONE_ACCOUNT_ID 
+                 -k $MANAGED_QUESTIONS_JUPITERONE_API_KEY 
+                 -p ../target/jupiterone/questions/questions.yaml

--- a/.github/workflows/questions.yml
+++ b/.github/workflows/questions.yml
@@ -1,5 +1,5 @@
 name: Questions
-on: [pull_request_target, pull_request]
+on: [pull_request_target]
 
 jobs:
   validate:

--- a/.github/workflows/questions.yml
+++ b/.github/workflows/questions.yml
@@ -1,5 +1,5 @@
 name: Questions
-on: [pull_request_target]
+on: [pull_request_target, pull_request]
 
 jobs:
   validate:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "type-check": "tsc",
     "test:env": "LOAD_ENV=1 yarn test",
     "test": "yarn validate:questions:dry && yarn jest",
-    "test:ci": "yarn validate:questions && yarn lint && yarn type-check",
+    "test:ci": "yarn lint && yarn type-check && yarn test",
     "build": "./build.sh",
     "prepush": "yarn lint && yarn type-check && jest --changedSince main",
     "tf": "cd terraform && env `grep -v '^#' .env` terraform $1",


### PR DESCRIPTION
The existing workflow prevents forked PRs from ever passing, because they are disallowed access to the proper environment variables. This was first experienced in https://github.com/JupiterOne/graph-azure/pull/450 

Specifically, this issue is holding up https://github.com/JupiterOne/graph-google-cloud/pull/415