### PR TITLE
Adding in optional FOLDER_ID to filter by folder

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -131,6 +131,8 @@ gcloud services enable \
   accesscontextmanager.googleapis.com
 ```
 
+NOTE: This may need broken up into multiple commands. The max batch size is 20.
+
 ### Creating Google Cloud project service account
 
 A
@@ -221,6 +223,7 @@ SERVICE_ACCOUNT_KEY_FILE={...}
 PROJECT_ID="my-j1-proj"
 ORGANIZATION_ID=""
 CONFIGURE_ORGANIZATION_PROJECTS=false
+FOLDER_ID""
 ```
 
 #### `SERVICE_ACCOUNT_KEY_FILE` {string}
@@ -257,6 +260,19 @@ yarn create-env-file ~/SERVICE_ACCOUNT_FILE_PATH_HERE.json
 Optional Google Cloud project ID to target for ingestion. A service account key
 can be generated from a specific project, and the JupiterOne integration can use
 these credentials to target a different project.
+
+#### `FOLDER_ID` {string?}
+
+Optional Google Cloud folder to target for ingestion. If no folder is provided,
+ingestion will be performed at the org level.
+
+Currently, this only takes in a single folder ID. This integration has
+historically been designed such that it will have multiple integrations per
+overall organization. Similarly, for the case where ingestion should be
+restricted to a group of completely independent folders within an organization
+instead of just a single folder, multiple integration instances for each folder
+area should be utilized to create "main" integrations that then build out
+project integrations via the CONFIGURE_ORGANIZATION_PROJECTS flag.
 
 ### Run tests against Google Cloud project
 

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -200,6 +200,7 @@ export default async function getStepStartStates(
       organizationId: config.organizationId,
       serviceAccountKeyEmail: config.serviceAccountKeyConfig.client_email,
       serviceAccountKeyProjectId: config.serviceAccountKeyConfig.project_id,
+      folderId: config.folderId,
     },
     'Starting integration with config',
   );

--- a/src/google-cloud/client.ts
+++ b/src/google-cloud/client.ts
@@ -56,6 +56,7 @@ export async function iterateApi<T>(
 export class Client {
   readonly projectId: string;
   readonly organizationId?: string;
+  readonly folderId?: string;
 
   private credentials: CredentialBody;
   private auth: BaseExternalAccountClient;
@@ -71,6 +72,7 @@ export class Client {
       client_email: config.serviceAccountKeyConfig.client_email,
       private_key: config.serviceAccountKeyConfig.private_key,
     };
+    this.folderId = config.folderId;
     this.onRetry = onRetry;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,9 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> =
         type: 'boolean',
         mask: false,
       },
+      folderId: {
+        type: 'string',
+      },
     },
     getStepStartStates,
     integrationSteps: [

--- a/src/steps/resource-manager/index.ts
+++ b/src/steps/resource-manager/index.ts
@@ -120,6 +120,10 @@ export async function fetchResourceManagerFolders(
     `organizations/${client.organizationId}`,
   );
   if (organizationEntity) {
+    let folderParent;
+    if (client.folderId) {
+      folderParent = 'folders/' + client.folderId;
+    }
     // Iterate organization's folders (starting point)
     await client.iterateFolders(async (folder) => {
       const folderEntity = createFolderEntity(folder);
@@ -135,7 +139,7 @@ export async function fetchResourceManagerFolders(
       );
 
       await getAllInnerFolders(client, folderEntity, folder.name!);
-    });
+    }, folderParent);
   }
 }
 
@@ -147,10 +151,16 @@ export async function buildOrgFolderProjectMappedRelationships(
     instance: { config },
   } = context;
   const client = new ResourceManagerClient({ config });
+
   const organizationEntity = await jobState.findEntity(
     `organizations/${client.organizationId}`,
   );
   // Organization -> HAS -> Projects
+  let folderParent;
+  if (config.folderId) {
+    folderParent = 'folders/' + config.folderId;
+  }
+
   if (organizationEntity) {
     await client.iterateProjects(async (project) => {
       const projectEntity = createProjectEntity(client.projectId, project);
@@ -171,7 +181,7 @@ export async function buildOrgFolderProjectMappedRelationships(
           },
         }),
       );
-    });
+    }, folderParent);
   }
 
   // Folder -> HAS (mappedRelationship) -> Projects

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface SerializedIntegrationConfig extends IntegrationInstanceConfig {
    */
   projectId?: string;
   configureOrganizationProjects?: boolean;
+  folderId?: string;
 }
 
 export interface IntegrationConfig extends SerializedIntegrationConfig {


### PR DESCRIPTION
Adding in optional FOLDER_ID to filter down to a specific folder within an organization for ingestion.  This is currently only restricting what folders and projects are ingested and is not doing anything to further restrict other entities.  We may want to rework or add additional filtering based on user or developer feedback.