### PR TITLE
INT-2448 - Change cloud run service key and its typeAndKeyFromResourceIdentifier

### DIFF
--- a/src/steps/cloud-run/__snapshots__/converters.test.ts.snap
+++ b/src/steps/cloud-run/__snapshots__/converters.test.ts.snap
@@ -197,7 +197,7 @@ Object {
   "_class": Array [
     "Service",
   ],
-  "_key": "cloudrun_service:fce2d165-9ccb-4b6c-9204-67362d41aadd",
+  "_key": "projects/j1-gc-integration-dev-v2/locations/us-central1/services/example-cloud-run-service",
   "_rawData": Array [
     Object {
       "name": "default",

--- a/src/steps/cloud-run/__snapshots__/index.test.ts.snap
+++ b/src/steps/cloud-run/__snapshots__/index.test.ts.snap
@@ -7,7 +7,7 @@ Object {
       "_class": Array [
         "Service",
       ],
-      "_key": "cloudrun_service:fce2d165-9ccb-4b6c-9204-67362d41aadd",
+      "_key": "projects/j1-gc-integration-dev-v2/locations/us-central1/services/example-cloud-run-service",
       "_rawData": Array [
         Object {
           "name": "default",
@@ -231,8 +231,8 @@ Object {
   "collectedRelationships": Array [
     Object {
       "_class": "MANAGES",
-      "_fromEntityKey": "cloudrun_service:fce2d165-9ccb-4b6c-9204-67362d41aadd",
-      "_key": "cloudrun_service:fce2d165-9ccb-4b6c-9204-67362d41aadd|manages|cloudrun_configuration:f190d809-4de1-4eb3-80bb-ad0ac9954f85",
+      "_fromEntityKey": "projects/j1-gc-integration-dev-v2/locations/us-central1/services/example-cloud-run-service",
+      "_key": "projects/j1-gc-integration-dev-v2/locations/us-central1/services/example-cloud-run-service|manages|cloudrun_configuration:f190d809-4de1-4eb3-80bb-ad0ac9954f85",
       "_toEntityKey": "cloudrun_configuration:f190d809-4de1-4eb3-80bb-ad0ac9954f85",
       "_type": "google_cloud_run_service_manages_configuration",
       "displayName": "MANAGES",
@@ -255,7 +255,7 @@ Object {
       "_class": Array [
         "Service",
       ],
-      "_key": "cloudrun_service:fce2d165-9ccb-4b6c-9204-67362d41aadd",
+      "_key": "projects/j1-gc-integration-dev-v2/locations/us-central1/services/example-cloud-run-service",
       "_rawData": Array [
         Object {
           "name": "default",
@@ -457,8 +457,8 @@ Object {
   "collectedRelationships": Array [
     Object {
       "_class": "MANAGES",
-      "_fromEntityKey": "cloudrun_service:fce2d165-9ccb-4b6c-9204-67362d41aadd",
-      "_key": "cloudrun_service:fce2d165-9ccb-4b6c-9204-67362d41aadd|manages|cloudrun_route:f538487c-6e93-4038-9f6a-b7936cc4dd04",
+      "_fromEntityKey": "projects/j1-gc-integration-dev-v2/locations/us-central1/services/example-cloud-run-service",
+      "_key": "projects/j1-gc-integration-dev-v2/locations/us-central1/services/example-cloud-run-service|manages|cloudrun_route:f538487c-6e93-4038-9f6a-b7936cc4dd04",
       "_toEntityKey": "cloudrun_route:f538487c-6e93-4038-9f6a-b7936cc4dd04",
       "_type": "google_cloud_run_service_manages_route",
       "displayName": "MANAGES",
@@ -481,7 +481,7 @@ Object {
       "_class": Array [
         "Service",
       ],
-      "_key": "cloudrun_service:fce2d165-9ccb-4b6c-9204-67362d41aadd",
+      "_key": "projects/j1-gc-integration-dev-v2/locations/us-central1/services/example-cloud-run-service",
       "_rawData": Array [
         Object {
           "name": "default",

--- a/src/steps/cloud-run/converters.test.ts
+++ b/src/steps/cloud-run/converters.test.ts
@@ -16,6 +16,8 @@ describe('#createCloudRunServiceEntity', () => {
       createCloudRunServiceEntity(
         getMockCloudRunService(),
         DEFAULT_INTEGRATION_CONFIG_PROJECT_ID,
+        // This would otherwise be returned by cacheCloudRunServiceKeyAndUid()
+        `projects/${DEFAULT_INTEGRATION_CONFIG_PROJECT_ID}/locations/us-central1/services/example-cloud-run-service`,
       ),
     ).toMatchSnapshot();
   });

--- a/src/steps/cloud-run/converters.ts
+++ b/src/steps/cloud-run/converters.ts
@@ -20,8 +20,12 @@ export interface MetadataComputedPropertyData {
   duplicateProperties: string[];
 }
 
-export function getCloudRunServiceKey(uid: string) {
-  return `cloudrun_service:${uid}`;
+export function getCloudRunServiceKey(
+  projectId: string,
+  location: string,
+  name: string,
+) {
+  return `projects/${projectId}/locations/${location}/services/${name}`;
 }
 
 export function getCloudRunRouteKey(uid: string) {
@@ -35,6 +39,7 @@ export function getCloudRunConfigurationKey(uid: string) {
 export function createCloudRunServiceEntity(
   data: run_v1.Schema$Service,
   projectId: string,
+  key: string,
 ) {
   // Build webLink
   let webLink = '';
@@ -54,7 +59,7 @@ export function createCloudRunServiceEntity(
       assign: {
         _class: ENTITY_CLASS_CLOUD_RUN_SERVICE,
         _type: ENTITY_TYPE_CLOUD_RUN_SERVICE,
-        _key: getCloudRunServiceKey(data.metadata?.uid as string),
+        _key: key,
         name: data.metadata?.name,
         function: ['workload-management'],
         displayName: data.metadata?.name as string,

--- a/src/utils/iamBindings/__snapshots__/getTypeAndKeyFromResourceIdentifier.test.ts.snap
+++ b/src/utils/iamBindings/__snapshots__/getTypeAndKeyFromResourceIdentifier.test.ts.snap
@@ -59,7 +59,7 @@ Object {
 exports[`getTypeAndKeyFromResourceIdentifier should find the correct keys for all available resources 8`] = `
 Object {
   "identifier": "//run.googleapis.com/projects/12345/locations/us-east1/services/abcdef12345",
-  "key": "cloudrun_service:abcdef12345",
+  "key": "projects/12345/locations/us-east1/services/abcdef12345",
   "type": "google_cloud_run_service",
 }
 `;

--- a/src/utils/iamBindings/typeToKeyGeneratorMap.ts
+++ b/src/utils/iamBindings/typeToKeyGeneratorMap.ts
@@ -13,7 +13,6 @@ import {
   BIG_QUERY_TABLE_ENTITY_TYPE,
 } from '../../steps/big-query';
 import { ENTITY_TYPE_CLOUD_RUN_SERVICE } from '../../steps/cloud-run/constants';
-import { getCloudRunServiceKey } from '../../steps/cloud-run/converters';
 import {
   ENTITY_TYPE_COMPUTE_BACKEND_BUCKET,
   ENTITY_TYPE_COMPUTE_BACKEND_SERVICE,
@@ -115,9 +114,7 @@ export const J1_TYPE_TO_KEY_GENERATOR_MAP: {
       context!.jobState,
       finalIdentifierKeyMap(id),
     )) ?? finalIdentifierKeyMap(id),
-  [ENTITY_TYPE_CLOUD_RUN_SERVICE]: customPrefixAndIdKeyMap(
-    getCloudRunServiceKey,
-  ),
+  [ENTITY_TYPE_CLOUD_RUN_SERVICE]: fullPathKeyMap,
   [ENTITY_TYPE_COMPUTE_BACKEND_BUCKET]: selfLinkKeyMap,
   [ENTITY_TYPE_COMPUTE_BACKEND_SERVICE]: selfLinkKeyMap,
   [ENTITY_TYPE_COMPUTE_DISK]: customPrefixAndIdKeyMap(getComputeDiskKey),

--- a/src/utils/jobState.ts
+++ b/src/utils/jobState.ts
@@ -39,7 +39,6 @@ export async function cacheCloudRunServiceKeyAndUid(
   const uid = cloudRunService.metadata?.uid;
   const key = getCloudRunServiceKey(projectId, location, name as string);
 
-  await jobState.setData(`cloudRunServiceKey:${key}`, uid);
   await jobState.setData(`cloudRunServiceUid:${uid}`, key);
 
   return key;


### PR DESCRIPTION
This PR fixes the bug associated with Cloud Asset's `createApiServiceToAnyResourceRelationships` step trying to process `iamBinding` that is related to Cloud Run service.

A different key format was used for Cloud Run Service than what the above-mentioned step was searching for, resulting in it failing to find it and ending up creating multiple mapped relationships where it ultimately failed with "Duplicate _key detected" error.

I had to introduce [cacheCloudRunServiceKeyAndUid](https://github.com/JupiterOne/graph-google-cloud/blob/fix/cloud-asset-cloud-run-key-bug/src/utils/jobState.ts#L29) since CloudRunRoutes and CloudRunConfigurations needed to find the CloudRunService, however, they have the `uid` and not all of the necessary parameters for creating the new key. This allows them to exchange the uid for the key.

To save some duplicate code/calls, I made the cacheCloudRunServiceKeyAndUid also return the key so that it can immediately be used [here](https://github.com/JupiterOne/graph-google-cloud/blob/fix/cloud-asset-cloud-run-key-bug/src/steps/cloud-run/index.ts#L51). I like it and dislike it at the same time, perhaps it's better if I just regenerate it again without trying anything fancy? My concern is people won't usually expect this function to return a value (especially with its current name - I could also add "AndReturnsKey" but it's already long as is), that said it saves few lines of code, and even if you do nothing with the returned value it still works as expected.

Other changes include choosing [different typeToKey](https://github.com/JupiterOne/graph-google-cloud/blob/fix/cloud-asset-cloud-run-key-bug/src/utils/iamBindings/typeToKeyGeneratorMap.ts#L117) for Cloud Run Service.