### PR TITLE
v2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## Unreleased
 
+## 2.8.1 - 2022-03-08
+
 ### Changed
 
 - Decoupled `fetch-sql-admin-instances` step from key vault dependencies. This

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google-cloud",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "A graph conversion tool for https://cloud.google.com/",
   "license": "MPL-2.0",
   "main": "src/index.js",


### PR DESCRIPTION
## 2.8.1 - 2022-03-08

### Changed

- Decoupled `fetch-sql-admin-instances` step from key vault dependencies. This
  allows the SQL admin step to execute successfully even if key vault steps are
  disabled.