### PR TITLE
Add support for token-based authentication

### DIFF
--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -153,9 +153,9 @@ function validateInvocationConfig(
   const { instance } = context;
   const { config } = instance;
 
-  if (!config.serviceAccountKeyFile) {
+  if (!config.serviceAccountKeyFile && !config.accessToken) {
     throw new IntegrationValidationError(
-      'Missing a required integration config value {serviceAccountKeyFile}',
+      'Missing a required integration config value {serviceAccountKeyFile} or {accessToken}',
     );
   }
 }
@@ -200,8 +200,6 @@ export default async function getStepStartStates(
       projectId: config.projectId,
       configureOrganizationProjects: config.configureOrganizationProjects,
       organizationId: config.organizationId,
-      serviceAccountKeyEmail: config.serviceAccountKeyConfig.client_email,
-      serviceAccountKeyProjectId: config.serviceAccountKeyConfig.project_id,
       folderId: config.folderId,
     },
     'Starting integration with config',
@@ -209,9 +207,7 @@ export default async function getStepStartStates(
 
   logger.publishEvent({
     name: 'integration_config',
-    description: `Starting Google Cloud integration with service account (email=${
-      config.serviceAccountKeyConfig.client_email
-    }, configureOrganizationProjects=${!!config.configureOrganizationProjects})`,
+    description: `Starting Google Cloud integration (project=${config.projectId}, configureOrganizationProjects=${!!config.configureOrganizationProjects})`,
   });
 
   const masterOrgInstance = isMasterOrganizationInstance(config);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -189,7 +189,7 @@ async function validateInvocationInvalidConfigTest({
     expect(err instanceof IntegrationValidationError).toBe(true);
     expect(err.message).toEqual(
       expectedErrorMessage ||
-        'Missing a required integration config value {serviceAccountKeyFile}',
+        'Missing a required integration config value {serviceAccountKeyFile} or {accessToken}',
     );
     failed = true;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,10 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> =
         type: 'string',
         mask: true,
       },
+      accessToken: {
+        type: 'string',
+        mask: true,
+      },
       projectId: {
         type: 'string',
       },

--- a/src/steps/storage/index.ts
+++ b/src/steps/storage/index.ts
@@ -58,7 +58,7 @@ export async function fetchStorageBuckets(
 
     const bucketEntity = createCloudStorageBucketEntity({
       data: bucket,
-      projectId: config.serviceAccountKeyConfig.project_id,
+      projectId: bucket.projectNumber || client.sourceProjectId,
       bucketPolicy,
       publicAccessPreventionPolicy,
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,8 @@ export type IntegrationStepContext =
   IntegrationStepExecutionContext<IntegrationConfig>;
 
 export interface SerializedIntegrationConfig extends IntegrationInstanceConfig {
-  serviceAccountKeyFile: string;
+  serviceAccountKeyFile?: string;
+  accessToken?: string;
   organizationId?: string;
   /**
    * The project ID that this integration should target for ingestion. This
@@ -26,7 +27,7 @@ export interface SerializedIntegrationConfig extends IntegrationInstanceConfig {
 }
 
 export interface IntegrationConfig extends SerializedIntegrationConfig {
-  serviceAccountKeyConfig: ParsedServiceAccountKeyFile;
+  serviceAccountKeyConfig?: ParsedServiceAccountKeyFile;
   // HACK - used to prevent binding step ingestion for large accounts. Think twice before using.
   markBindingStepsAsPartial?: boolean;
 }

--- a/src/utils/integrationConfig.ts
+++ b/src/utils/integrationConfig.ts
@@ -2,7 +2,7 @@ import { IntegrationConfig, SerializedIntegrationConfig } from '../types';
 import { parseServiceAccountKeyFile } from './parseServiceAccountKeyFile';
 
 /**
- * The incoming Google Cloud config includes a `serviceAccountKeyFile` property
+ * The incoming Google Cloud config may include a `serviceAccountKeyFile` property
  * that we need to deserialize. We will override the value of the
  * `IntegrationExecutionContext` `config` with the return value of this function,
  * so that the deserialized config can be used throughout all of the steps.
@@ -10,6 +10,10 @@ import { parseServiceAccountKeyFile } from './parseServiceAccountKeyFile';
 export function deserializeIntegrationConfig(
   serializedIntegrationConfig: SerializedIntegrationConfig,
 ): IntegrationConfig {
+  if (!serializedIntegrationConfig.serviceAccountKeyFile) {
+    return serializedIntegrationConfig;
+  }
+
   const parsedServiceAccountKeyFile = parseServiceAccountKeyFile(
     serializedIntegrationConfig.serviceAccountKeyFile,
   );

--- a/src/utils/maybeDefaultProjectIdOnEntity.ts
+++ b/src/utils/maybeDefaultProjectIdOnEntity.ts
@@ -25,6 +25,6 @@ export function maybeDefaultProjectIdOnEntity(context, entity: Entity): Entity {
     projectId:
       entity.projectId ??
       context.instance.config.projectId ??
-      context.instance.config.serviceAccountKeyConfig.project_id,
+      context.instance.config.serviceAccountKeyConfig?.project_id,
   };
 }


### PR DESCRIPTION
This PR adds an optional configuration parameter to allow users to specify a GCP access token with the `ACCESS_TOKEN` environment variable.

We tried to find the best way to make this change, but it's tricky to implement with the client libraries and this was our first experience with the JupiterOne SDK. We're very open to feedback on the change.