### PR TITLE
Update retry maxAttempts to 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## Unreleased
 
+## 2.9.4 - 2022-03-22
+
 ### Changed
 
 - Update retry `maxAttempts: 6` in `withErrorHandling`, increasing the total

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- Update retry `maxAttempts: 6` in `withErrorHandling`, increasing the total
+  retry time from 40s -> 90s
+
 ## 2.9.3 - 2022-03-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google-cloud",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "description": "A graph conversion tool for https://cloud.google.com/",
   "license": "MPL-2.0",
   "main": "src/index.js",

--- a/src/google-cloud/client.ts
+++ b/src/google-cloud/client.ts
@@ -121,8 +121,8 @@ export function withErrorHandling<T extends (...params: any) => any>(
       {
         delay: 2_000,
         timeout: 60_000, // Need to set a timeout, otherwise we might wait for a response indefinitely.
-        maxAttempts: 5,
-        factor: 2.25, // 2s, 4.5s, 10.125s, 22.78125s, 51.2578125 (90.6640652s)
+        maxAttempts: 6,
+        factor: 2.25, //t=0s, 2s, 4.5s, 10.125s, 22.78125s, 51.2578125 (90.6640652s)
         handleError(err, ctx) {
           const newError = handleApiClientError(err);
 


### PR DESCRIPTION
## 2.9.4 - 2022-03-22

### Changed

- Update retry `maxAttempts: 6` in `withErrorHandling`, increasing the total
  retry time from 40s -> 90s
