### PR TITLE
Redact help token value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- Redacted help token value from `The metric quota for X is exhausted` errors.
+
 ## 2.11.0 - 2022-04-01
 
 ### Changed


### PR DESCRIPTION
This just redacts the Help Token value from error messages (and causes - since it can be seen at few places during the error stack trace), in case it's customer specific value.