### PR TITLE
Adding a query for service account key expiration

### DIFF
--- a/jupiterone/questions/questions.yaml
+++ b/jupiterone/questions/questions.yaml
@@ -1317,6 +1317,33 @@ questions:
   - gke
   - compute
   - network
+  - id: integration-question-google-cloud-service-account-key-expires-before-date
+  title: Which user-managed/external keys for service accounts are set to expire before or on a certain date?
+  description: >
+    Service Account keys consist of a key ID (Private_key_Id) and Private key, which are used to sign
+     programmatic requests users make to Google cloud services accessible to that particular service 
+     account.mInput a date in ISO 8601 format to assess which keys will expire before or on that date.
+  queries:
+    query: |
+      FIND google_iam_service_account AS serviceAccount
+        THAT HAS google_iam_service_account_key
+        WITH expiresOn <= date({{ISO8601.date}})
+      return
+      serviceAccount.id,
+      serviceAccount.email,
+      serviceAccount.description,
+      serviceAccount.enabled,
+      serviceAccount.webLink,
+      google_iam_service_account_key.name,
+      google_iam_service_account_key.type,
+      google_iam_service_account_key.createdOn,
+      google_iam_service_account_key.expiresOn
+
+  tags:
+  - google-cloud
+  - service-account
+  - access
+  - iam
 ################################################################################
 # End Section 7: Kubernetes
 ################################################################################


### PR DESCRIPTION
This query allows the user to input an ISO 8601 format date in order to understanding which service account keys expire before or on that date. 