### PR TITLE
Fix CIS Google Cloud Foundations requirement 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to
 
 ## Unreleased
 
+## 2.13.0 - 2022-04-22
+
+### Added
+
+- Added new managed question
+
+  > Which Google Cloud Functions have runtime that are deprecated?
+
+### Fixed
+
+- Fix CIS Google Cloud Foundations requirement 1.6 managed question
+
 ## 2.12.0 - 2022-04-21
 
 ### Added

--- a/jupiterone/questions/questions.yaml
+++ b/jupiterone/questions/questions.yaml
@@ -78,7 +78,7 @@ questions:
 
 - id: integration-question-google-cloud-function-deprecated-runtime
   title: Which Google Cloud Functions have runtime that are deprecated?
-  description: 
+  description:
     Returns Google functions that are not using a supported runtime.
   queries:
   - name: bad
@@ -204,7 +204,7 @@ questions:
   queries:
   - name: good
     query: |
-      find google_iam_service_account as user
+      find google_user as user
         that ASSIGNED google_iam_binding
         that USES google_iam_role as role
         where
@@ -1347,6 +1347,3 @@ questions:
 ################################################################################
 # End Section 7: Kubernetes
 ################################################################################
-
-
-  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google-cloud",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "A graph conversion tool for https://cloud.google.com/",
   "license": "MPL-2.0",
   "main": "src/index.js",


### PR DESCRIPTION
The requirement should have been using `google_user` instead of
`google_iam_service_account`.