### PR TITLE
INT-3496 - Fix managed question to use correct `_type` query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to
 
 ## Unreleased
 
+## 2.13.1 - 2022-04-23
+
+### Fixed
+
+- Fix managed question to use correct `_type` query
+
+  > Ensure that IAM users are not assigned the Service Account User or Service
+  > Account Token Creator roles at project level
+
+  The managed question `good` query is using the correct `_type`, while the
+  `bad` query is not. Both queries should be using `google_user` instead of
+  `google_iam_service_account`.
+
+  Additionally, both `good` and `bad` queries have been optimized to use `WITH`
+  query filters instead of `WHERE`, since `WITH` performs post-traversal
+  filtering.
+
 ## 2.13.0 - 2022-04-22
 
 ### Added

--- a/jupiterone/questions/questions.yaml
+++ b/jupiterone/questions/questions.yaml
@@ -204,25 +204,27 @@ questions:
   queries:
   - name: good
     query: |
-      find google_user as user
-        that ASSIGNED google_iam_binding
-        that USES google_iam_role as role
-        where
-          role.name!="roles/iam.serviceAccountUser" and
-          role.name!="roles/iam.serviceAccountTokenCreator"
-      return
-        user.name,
+      FIND google_user AS user
+        THAT ASSIGNED google_iam_binding
+        THAT USES google_iam_role
+          WITH (
+            role.name != "roles/iam.serviceAccountUser" AND
+            role.name != "roles/iam.serviceAccountTokenCreator"
+          ) AS role
+      RETURN
+        user.username,
         role.name
   - name: bad
     query: |
-      find google_iam_service_account as user
-        that ASSIGNED google_iam_binding
-        that USES google_iam_role as role
-        where
-          role.name="roles/iam.serviceAccountUser" or
-          role.name="roles/iam.serviceAccountTokenCreator"
-      return
-        user.name,
+      FIND google_user AS user
+        THAT ASSIGNED google_iam_binding
+        THAT USES google_iam_role
+          WITH (
+            role.name ="roles/iam.serviceAccountUser" OR
+            role.name ="roles/iam.serviceAccountTokenCreator"
+          ) AS role
+      RETURN
+        user.username,
         role.name
   tags:
   - google-cloud

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google-cloud",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "A graph conversion tool for https://cloud.google.com/",
   "license": "MPL-2.0",
   "main": "src/index.js",


### PR DESCRIPTION
The managed question `good` query is using the correct `_type`,
while the `bad` query is not. Both queries should be using
`google_user` instead of `google_iam_service_account`.

Additionally, both `good` and `bad` queries have been optimized
to use `WITH` query filters instead of `WHERE`, since `WITH`
performs post-traversal filtering.