### PR TITLE
Remove google_cloud_api_service with enabled = false question

### DIFF
--- a/jupiterone/questions/questions.yaml
+++ b/jupiterone/questions/questions.yaml
@@ -5,17 +5,6 @@ questions:
 ################################################################################
 # Generic non-compliance questions
 ################################################################################
-- id: integration-question-google-cloud-disabled-project-services
-  title: Which Google Cloud API services are disabled for my project?
-  description:
-    Finds all disabled Google Cloud API services in a specified project
-  queries:
-  - query: |
-      FIND google_cloud_api_service WITH projectId = '{{projectId}}' AND enabled = false
-  tags:
-  - google-cloud
-  - service
-  - api
 - id: integration-question-google-cloud-kubernetes-route-based-clusters
   title: Which Kubernetes clusters use Google Cloud Routes for traffic routing between pods?
   description:


### PR DESCRIPTION
We no longer ingest `google_cloud_api_service with enabled = false`