### PR TITLE
Fix orgpolicy.policy.get permission refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ and this project adheres to
 
 ## Unreleased
 
+### Fixed
+
+- Fixed user messaging about optional `orgpolicy.policy.get` permission
+
 ## 2.15.0 - 2022-05-11
 
 ### Changed
 
 - Changed the `fetch-api-services` step to only fetch enabled services. This
   lowers the number of service requests made by approximately 40 times.
+
 ## 2.14.0 - 2022-05-03
 
 ### Added

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -150,7 +150,7 @@ appengine.applications.get
 binaryauthorization.policy.get
 cloudasset.assets.searchAllIamPolicies
 compute.projects.get
-orgpolicy.policies.get
+orgpolicy.policy.get
 ```
 
 See the
@@ -214,7 +214,7 @@ access, it is therefore recommended that the following permission is also
 included in the custom role above:
 
 ```
-orgpolicy.policies.get
+orgpolicy.policy.get
 ```
 
 1. Navigate to the Cloud Resource Manager for that organization and

--- a/src/steps/storage/index.ts
+++ b/src/steps/storage/index.ts
@@ -34,7 +34,7 @@ export async function fetchStorageBuckets(
     logger.publishEvent({
       name: 'missing_permission',
       description:
-        '"orgpolicy.policies.get" is not a required permission to run the Google Cloud integration, but is required for getting organization policy for "storage.publicAccessPrevention"',
+        '"orgpolicy.policy.get" is not a required permission to run the Google Cloud integration, but is required for getting organization policy for "storage.publicAccessPrevention"',
     });
   }
 


### PR DESCRIPTION
Our messaging asked users to add the `orgpolicy.policies.get` permission, but it actually should have been `orgpolicy.policy.get`.