### PR TITLE
v2.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## Unreleased
 
+## 2.15.1 - 2022-05-23
+
 ### Fixed
 
 - Fixed user messaging about optional `orgpolicy.policy.get` permission

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google-cloud",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "A graph conversion tool for https://cloud.google.com/",
   "license": "MPL-2.0",
   "main": "src/index.js",


### PR DESCRIPTION
## 2.15.1 - 2022-05-23

### Fixed

- Fixed user messaging about optional `orgpolicy.policy.get` permission
