### PR TITLE
INT-2289 - Update docs regarding BigQuery permissions

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -153,15 +153,14 @@ compute.projects.get
 orgpolicy.policy.get
 ```
 
-For BigQuery, the following permissions are recommended:
+For BigQuery, the following _additional_ permissions are needed to ingest
+BigQuery datasets, models, and tables respectively:
 
 ```
 bigquery.datasets.get
 bigquery.models.getMetadata
 bigquery.tables.get
 ```
-
-This allows integration to properly ingest BigQuery datasets, models and tables.
 
 See the
 [Google Cloud custom role documentation](https://cloud.google.com/iam/docs/creating-custom-roles#creating_a_custom_role)

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -153,6 +153,16 @@ compute.projects.get
 orgpolicy.policy.get
 ```
 
+For BigQuery, the following permissions are recommended:
+
+```
+bigquery.datasets.get
+bigquery.models.getMetadata
+bigquery.tables.get
+```
+
+This allows integration to properly ingest BigQuery datasets, models and tables.
+
 See the
 [Google Cloud custom role documentation](https://cloud.google.com/iam/docs/creating-custom-roles#creating_a_custom_role)
 for additional information on how custom roles can be configured and assigned.


### PR DESCRIPTION
For BigQuery:
`bigquery.datasets.get`

This allows integration to see datasets (datasets house models/tables, so this is the starting point). If this permission isn’t set, the integration won’t show an error but the resulting datasets response will just be an empty list (it’s due to how GCP decided to make that particular endpoint work).

However with just that one permission added, the integration won’t be able to process the tables and models fully (it’ll be able to see them but not get all the metadata), hence the following two permissions are recommended:
`bigquery.models.getMetadata`
`bigquery.tables.get`

So, in total the following permissions are required to make full use of our integration:
`bigquery.datasets.get`
`bigquery.models.getMetadata`
`bigquery.tables.get`
