### PR TITLE
INT-4146 - Split GCP service API to role relationship creation into separate step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@ and this project adheres to
 
 ### Changed
 
-Rely on the individual steps to call service APIs instead of pre-calculating
-which service APIs are enabled in `getStepStartStates`. This should help
-drastically reduce the number of API calls to `serviceusage.googleapis.com`.
+- Rely on the individual steps to call service APIs instead of pre-calculating
+  which service APIs are enabled in `getStepStartStates`. This should help
+  drastically reduce the number of API calls to `serviceusage.googleapis.com`.
+
+### Fixed
+
+- Split service API to role relationship creation into separate step. If
+  collecting service API data fails, we should still ingest custom IAM roles.
 
 ## 2.15.1 - 2022-05-23
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google-cloud",
-  "version": "2.15.2-beta.1",
+  "version": "2.15.2-beta.2",
   "description": "A graph conversion tool for https://cloud.google.com/",
   "license": "MPL-2.0",
   "main": "src/index.js",

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -13,6 +13,7 @@ import { STEP_CLOUD_STORAGE_BUCKETS } from './steps/storage';
 import { ServiceUsageStepIds } from './steps/service-usage/constants';
 import {
   STEP_IAM_CUSTOM_ROLES,
+  STEP_IAM_CUSTOM_ROLE_SERVICE_API_RELATIONSHIPS,
   STEP_IAM_MANAGED_ROLES,
   STEP_IAM_SERVICE_ACCOUNTS,
 } from './steps/iam';
@@ -260,6 +261,7 @@ export default async function getStepStartStates(
     [STEP_CLOUD_FUNCTIONS_SERVICE_ACCOUNT_RELATIONSHIPS]: { disabled: false },
     [STEP_CLOUD_STORAGE_BUCKETS]: { disabled: false },
     [STEP_IAM_CUSTOM_ROLES]: { disabled: false },
+    [STEP_IAM_CUSTOM_ROLE_SERVICE_API_RELATIONSHIPS]: { disabled: false },
     [STEP_IAM_MANAGED_ROLES]: { disabled: false },
     [STEP_IAM_SERVICE_ACCOUNTS]: { disabled: false },
     [STEP_AUDIT_CONFIG_IAM_POLICY]: {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -26,6 +26,7 @@ import { STEP_CLOUD_STORAGE_BUCKETS } from './steps/storage';
 import { ServiceUsageStepIds } from './steps/service-usage/constants';
 import {
   STEP_IAM_CUSTOM_ROLES,
+  STEP_IAM_CUSTOM_ROLE_SERVICE_API_RELATIONSHIPS,
   STEP_IAM_MANAGED_ROLES,
   STEP_IAM_SERVICE_ACCOUNTS,
 } from './steps/iam';
@@ -588,6 +589,9 @@ describe('#getStepStartStates success', () => {
         disabled: false,
       },
       [STEP_DATAPROC_CLUSTER_KMS_RELATIONSHIPS]: {
+        disabled: false,
+      },
+      [STEP_IAM_CUSTOM_ROLE_SERVICE_API_RELATIONSHIPS]: {
         disabled: false,
       },
       [STEP_CREATE_CLUSTER_STORAGE_RELATIONSHIPS]: {

--- a/src/steps/iam/constants.ts
+++ b/src/steps/iam/constants.ts
@@ -1,5 +1,7 @@
 export const STEP_IAM_CUSTOM_ROLES = 'fetch-iam-custom-roles';
 export const STEP_IAM_MANAGED_ROLES = 'fetch-iam-managed-roles';
+export const STEP_IAM_CUSTOM_ROLE_SERVICE_API_RELATIONSHIPS =
+  'build-iam-custom-role-service-api-relationships';
 export const IAM_ROLE_ENTITY_CLASS = 'AccessRole';
 export const IAM_ROLE_ENTITY_TYPE = 'google_iam_role';
 

--- a/src/utils/iam.test.ts
+++ b/src/utils/iam.test.ts
@@ -238,16 +238,12 @@ describe('#getFullServiceApiNameFromPermission', () => {
 describe('#getUniqueFullServiceApiNamesFromRole', () => {
   test('should generate unique set service API names from permission', () => {
     expect(
-      getUniqueFullServiceApiNamesFromRole(
-        getMockIamRole({
-          includedPermissions: [
-            'binaryauthorization.policy.get',
-            'resourcemanager.projects.get',
-            'bigtable.tables.delete',
-            'binaryauthorization.attestors.update',
-          ],
-        }),
-      ),
+      getUniqueFullServiceApiNamesFromRole([
+        'binaryauthorization.policy.get',
+        'resourcemanager.projects.get',
+        'bigtable.tables.delete',
+        'binaryauthorization.attestors.update',
+      ]),
     ).toEqual([
       'binaryauthorization.googleapis.com',
       'cloudresourcemanager.googleapis.com',

--- a/src/utils/iam.ts
+++ b/src/utils/iam.ts
@@ -372,11 +372,11 @@ export function getFullServiceApiNameFromPermission(
 }
 
 export function getUniqueFullServiceApiNamesFromRole(
-  role: iam_v1.Schema$Role,
+  iamRoleIncludedPermissions: string[] | null | undefined,
 ): string[] {
   const serviceApiNameSet: Set<string> = new Set();
 
-  for (const permission of role.includedPermissions || []) {
+  for (const permission of iamRoleIncludedPermissions || []) {
     serviceApiNameSet.add(getFullServiceApiNameFromPermission(permission));
   }
 


### PR DESCRIPTION
If ingesting service APIs fails, we should still ingest custom IAM roles.