### PR TITLE
Release 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,17 @@ and this project adheres to
 
 ## Unreleased
 
+## 2.16.0 - 2022-08-25
+
 ### Added
 
 - Support for new GCP compute regions
+- Support optional `config.useEnablementsForStepStartStates` to call
+  listEnablements API before attempting to make API calls for all services
+- Support the following new entities:
+  - `google_cloud_secret`
+  - `google_cloud_secret_version`
+  - `google_cloud_build`
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google-cloud",
-  "version": "2.15.2-beta.5",
+  "version": "2.16.0",
   "description": "A graph conversion tool for https://cloud.google.com/",
   "license": "MPL-2.0",
   "main": "src/index.js",


### PR DESCRIPTION
## 2.16.0 - 2022-08-25

### Added

- Support for new GCP compute regions
- Support optional `config.useEnablementsForStepStartStates` to call
  listEnablements API before attempting to make API calls for all services
- Support the following new entities:
  - `google_cloud_secret`
  - `google_cloud_secret_version`
  - `google_cloud_build`

### Changed

- Do not throw if bigquery API returns
  `The project ${config.projectId} has not enabled BigQuery.`

- Rely on the individual steps to call service APIs instead of pre-calculating
  which service APIs are enabled in `getStepStartStates`. This should help
  drastically reduce the number of API calls to `serviceusage.googleapis.com`.

- Change KMS key ring client request code to iterate hardcoded list of project
  locations instead of hitting the KMS project location API. The KMS project
  location API was being hammered and could cause API quota issues.

### Fixed

- Split service API to role relationship creation into separate step. If
  collecting service API data fails, we should still ingest custom IAM roles.
