### PR TITLE
INT-5355 upgrade googleapis to support WorkerPools

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@lifeomic/attempt": "^3.0.0",
     "gaxios": "^4.2.1",
     "google-auth-library": "^7.1.0",
-    "googleapis": "^74.2.0",
+    "googleapis": "80.2.0",
     "lodash.get": "^4.4.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,10 +2730,10 @@ googleapis-common@^5.0.2:
     url-template "^2.0.8"
     uuid "^8.0.0"
 
-googleapis@^74.2.0:
-  version "74.2.0"
-  resolved "https://registry.yarnpkg.com/googleapis/-/googleapis-74.2.0.tgz#e3f44093594b56a13f6899e27fb842a7a6687a2a"
-  integrity sha512-AF8RwmTbz8GGIza9LViokOUAsrEkB6gKwvIGXbgWEWzZO1+DRsbKSstHotDgUA4zdXhVtGkOW7uqNs/wz4rYNA==
+googleapis@80.2.0:
+  version "80.2.0"
+  resolved "https://registry.yarnpkg.com/googleapis/-/googleapis-80.2.0.tgz#ddc5ed5689a228d77d9125e49f990abbc20dfbb6"
+  integrity sha512-lpl+ieuD5YErItTbex/zdtRTndNTZUmbo0eInBtiIe428FSFdjFVZ7+RUdLdiOtMQSxdD1vHe24SXjL3E5U2Nw==
   dependencies:
     google-auth-library "^7.0.2"
     googleapis-common "^5.0.2"


### PR DESCRIPTION
The reason behind this is to add support for new entities in cloudbuild that have been moved from alpha/beta to v1