### PR TITLE
INT-5579 Decouple `iterateApi` into `forEachPage` and `withErrorHandling`

### DIFF
--- a/src/google-cloud/client.test.ts
+++ b/src/google-cloud/client.test.ts
@@ -93,7 +93,7 @@ describe('withErrorHandling', () => {
           .fn()
           .mockRejectedValue(mockForbiddenError);
         const handledFunction = client.withErrorHandling(executionHandler);
-        await expect(handledFunction()).rejects.toThrow(J1Error);
+        await expect(handledFunction).rejects.toThrow(J1Error);
       });
     },
   );
@@ -102,9 +102,7 @@ describe('withErrorHandling', () => {
     const mockUnknownError = new Error() as any;
     const executionHandler = jest.fn().mockRejectedValue(mockUnknownError);
     const handledFunction = client.withErrorHandling(executionHandler);
-    await expect(handledFunction()).rejects.toThrow(
-      IntegrationProviderAPIError,
-    );
+    await expect(handledFunction).rejects.toThrow(IntegrationProviderAPIError);
   });
 
   test('should throw an IntegrationProviderAPIError on all unknown errors', async () => {
@@ -117,9 +115,7 @@ describe('withErrorHandling', () => {
       onRetry,
     });
 
-    await expect(handledFunction()).rejects.toThrow(
-      IntegrationProviderAPIError,
-    );
+    await expect(handledFunction).rejects.toThrow(IntegrationProviderAPIError);
 
     expect(onRetry).toHaveBeenCalledTimes(0);
   });
@@ -127,12 +123,9 @@ describe('withErrorHandling', () => {
   test('should pass parameters to the wrapped function return the result if no errors', async () => {
     const executionHandler = jest
       .fn()
-      .mockImplementation((...params) => Promise.resolve(params));
-    const handledFunction = client.withErrorHandling(executionHandler);
-    await expect(handledFunction('param1', 'param2')).resolves.toEqual([
-      'param1',
-      'param2',
-    ]);
+      .mockImplementation(() => Promise.resolve(['param1', 'param2']));
+    const response = await client.withErrorHandling(executionHandler);
+    expect(response).toEqual(['param1', 'param2']);
   });
 
   test('should retry if quota error received with 403 status code', async () => {
@@ -144,17 +137,14 @@ describe('withErrorHandling', () => {
     const executionHandler = jest
       .fn()
       .mockRejectedValueOnce(err)
-      .mockImplementationOnce((...params) => Promise.resolve(params));
+      .mockImplementationOnce(() => Promise.resolve(['param1', 'param2']));
 
     const onRetry = jest.fn();
-    const handledFunction = client.withErrorHandling(executionHandler, {
+    const response = await client.withErrorHandling(executionHandler, {
       onRetry,
     });
 
-    await expect(handledFunction('param1', 'param2')).resolves.toEqual([
-      'param1',
-      'param2',
-    ]);
+    expect(response).toEqual(['param1', 'param2']);
 
     expect(onRetry).toHaveBeenCalledTimes(1);
     expect(onRetry).toHaveBeenCalledWith(err);
@@ -167,17 +157,14 @@ describe('withErrorHandling', () => {
     const executionHandler = jest
       .fn()
       .mockRejectedValueOnce(err)
-      .mockImplementationOnce((...params) => Promise.resolve(params));
+      .mockImplementationOnce(() => Promise.resolve(['param1', 'param2']));
 
     const onRetry = jest.fn();
-    const handledFunction = client.withErrorHandling(executionHandler, {
+    const response = await client.withErrorHandling(executionHandler, {
       onRetry,
     });
 
-    await expect(handledFunction('param1', 'param2')).resolves.toEqual([
-      'param1',
-      'param2',
-    ]);
+    expect(response).toEqual(['param1', 'param2']);
 
     expect(onRetry).toHaveBeenCalledTimes(1);
     expect(onRetry).toHaveBeenCalledWith(err);

--- a/src/google-cloud/client.test.ts
+++ b/src/google-cloud/client.test.ts
@@ -79,7 +79,14 @@ describe('withErrorHandling', () => {
     projectId: 'projectId',
     serviceAccountKeyConfig: { project_id: 'serviceAccountProjectId' },
   } as unknown as IntegrationConfig;
-  const client = new Client({ config });
+
+  let client;
+  let onRetry;
+
+  beforeEach(() => {
+    onRetry = jest.fn();
+    client = new Client({ config, onRetry: onRetry });
+  });
 
   [IntegrationProviderAuthorizationError, IntegrationProviderAPIError].forEach(
     (J1Error) => {
@@ -110,10 +117,7 @@ describe('withErrorHandling', () => {
       .fn()
       .mockRejectedValue(new Error('Something esploded'));
 
-    const onRetry = jest.fn();
-    const handledFunction = client.withErrorHandling(executionHandler, {
-      onRetry,
-    });
+    const handledFunction = client.withErrorHandling(executionHandler);
 
     await expect(handledFunction).rejects.toThrow(IntegrationProviderAPIError);
 
@@ -139,10 +143,7 @@ describe('withErrorHandling', () => {
       .mockRejectedValueOnce(err)
       .mockImplementationOnce(() => Promise.resolve(['param1', 'param2']));
 
-    const onRetry = jest.fn();
-    const response = await client.withErrorHandling(executionHandler, {
-      onRetry,
-    });
+    const response = await client.withErrorHandling(executionHandler);
 
     expect(response).toEqual(['param1', 'param2']);
 
@@ -159,10 +160,7 @@ describe('withErrorHandling', () => {
       .mockRejectedValueOnce(err)
       .mockImplementationOnce(() => Promise.resolve(['param1', 'param2']));
 
-    const onRetry = jest.fn();
-    const response = await client.withErrorHandling(executionHandler, {
-      onRetry,
-    });
+    const response = await client.withErrorHandling(executionHandler);
 
     expect(response).toEqual(['param1', 'param2']);
 

--- a/src/google-cloud/client.ts
+++ b/src/google-cloud/client.ts
@@ -131,10 +131,6 @@ export class Client {
   }
 }
 
-export type WithErrorHandlingOptions = {
-  onRetry?: (err: any) => void;
-};
-
 /**
  * Codes unknown error into JupiterOne errors
  */

--- a/src/google-cloud/client.ts
+++ b/src/google-cloud/client.ts
@@ -84,7 +84,7 @@ export class Client {
     callback: (data: T) => Promise<void>,
   ) {
     return this.forEachPage(async (nextPageToken) => {
-      const result = await this.withErrorHandling(fn);
+      const result = await this.withErrorHandling(() => fn(nextPageToken));
       await callback(result.data);
 
       return result;

--- a/src/steps/cloud-run/client.ts
+++ b/src/steps/cloud-run/client.ts
@@ -1,5 +1,5 @@
-import { Client } from '../../google-cloud/client';
 import { google, run_v1 } from 'googleapis';
+import { Client } from '../../google-cloud/client';
 
 export class CloudRunClient extends Client {
   private client = google.run({ version: 'v1', retry: false });
@@ -9,20 +9,16 @@ export class CloudRunClient extends Client {
   ): Promise<void> {
     const auth = await this.getAuthenticatedServiceClient();
 
-    await this.iterateApi(
-      async () => {
-        // Doesn't support pageToken
-        return this.client.namespaces.services.list({
-          parent: `namespaces/${this.projectId}`,
-          auth,
-        });
-      },
-      async (data: run_v1.Schema$ListServicesResponse) => {
-        for (const service of data.items || []) {
-          await callback(service);
-        }
-      },
+    const response = await this.withErrorHandling(async () =>
+      this.client.namespaces.services.list({
+        parent: `namespaces/${this.projectId}`,
+        auth,
+      }),
     );
+
+    for (const service of response.data.items || []) {
+      await callback(service);
+    }
   }
 
   async iterateCloudRunRoutes(
@@ -30,20 +26,17 @@ export class CloudRunClient extends Client {
   ): Promise<void> {
     const auth = await this.getAuthenticatedServiceClient();
 
-    await this.iterateApi(
-      async () => {
-        // Doesn't support pageToken
-        return this.client.namespaces.routes.list({
+    const response = await this.withErrorHandling(
+      async () =>
+        await this.client.namespaces.routes.list({
           parent: `namespaces/${this.projectId}`,
           auth,
-        });
-      },
-      async (data: run_v1.Schema$ListRoutesResponse) => {
-        for (const route of data.items || []) {
-          await callback(route);
-        }
-      },
+        }),
     );
+
+    for (const route of response.data.items || []) {
+      await callback(route);
+    }
   }
 
   async iterateCloudRunConfigurations(
@@ -51,19 +44,16 @@ export class CloudRunClient extends Client {
   ): Promise<void> {
     const auth = await this.getAuthenticatedServiceClient();
 
-    await this.iterateApi(
-      async () => {
-        // Doesn't support pageToken
-        return this.client.namespaces.configurations.list({
+    const response = await this.withErrorHandling(
+      async () =>
+        await this.client.namespaces.configurations.list({
           parent: `namespaces/${this.projectId}`,
           auth,
-        });
-      },
-      async (data: run_v1.Schema$ListConfigurationsResponse) => {
-        for (const configuration of data.items || []) {
-          await callback(configuration);
-        }
-      },
+        }),
     );
+
+    for (const configuration of response.data.items || []) {
+      await callback(configuration);
+    }
   }
 }

--- a/src/steps/compute/client.ts
+++ b/src/steps/compute/client.ts
@@ -1,12 +1,12 @@
-import { google, compute_v1 } from 'googleapis';
+import { BaseExternalAccountClient } from 'google-auth-library';
+import { compute_v1, google } from 'googleapis';
 import { Client, PageableGaxiosResponse } from '../../google-cloud/client';
 import { iterateRegions, iterateRegionZones } from '../../google-cloud/regions';
-import { BaseExternalAccountClient } from 'google-auth-library';
 
 export class ComputeClient extends Client {
   private client = google.compute({ version: 'v1', retry: false });
 
-  private async iterateComputeApi<T>(
+  private async iterateComputeApi<T extends { nextPageToken?: string | null }>(
     fn: (params: {
       auth: BaseExternalAccountClient;
       zone: string;

--- a/src/steps/compute/client.ts
+++ b/src/steps/compute/client.ts
@@ -6,7 +6,7 @@ import { iterateRegions, iterateRegionZones } from '../../google-cloud/regions';
 export class ComputeClient extends Client {
   private client = google.compute({ version: 'v1', retry: false });
 
-  private async iterateComputeApi<T extends { nextPageToken?: string | null }>(
+  private async iterateComputeApi<T>(
     fn: (params: {
       auth: BaseExternalAccountClient;
       zone: string;

--- a/src/steps/sql-admin/client.ts
+++ b/src/steps/sql-admin/client.ts
@@ -9,19 +9,15 @@ export class SQLAdminClient extends Client {
   ): Promise<void> {
     const auth = await this.getAuthenticatedServiceClient();
 
-    await this.iterateApi(
-      async (nextPageToken) => {
-        return this.client.instances.list({
-          project: this.projectId,
-          auth,
-          pageToken: nextPageToken,
-        });
-      },
-      async (data: sqladmin_v1beta4.Schema$DatabasesListResponse) => {
-        for (const sqlInstance of data.items || []) {
-          await callback(sqlInstance);
-        }
-      },
+    const response = await this.withErrorHandling(async () =>
+      this.client.instances.list({
+        project: this.projectId,
+        auth,
+      }),
     );
+
+    for (const sqlInstance of response.data.items || []) {
+      await callback(sqlInstance);
+    }
   }
 }


### PR DESCRIPTION
Pushed with `--no-verify` due to permission on my current user:

```
    PollyError: [Polly] [persister:JupiterOneIntegationFSPersister] Cannot persist response for [GET] https://iam.googleapis.com/v1/roles?view=FULL&showDeleted=true because the status code was 401 and `recordFailedRequests` is `false`

PollyError: [Polly] [persister:JupiterOneIntegationFSPersister] Cannot persist response for [GET] https://iam.googleapis.com/v1/roles?view=FULL&showDeleted=true because the status code was 401 and `recordFailedRequests` is `false`


    Provider API failed at https://iam.googleapis.com/v1/roles?view=FULL&showDeleted=true: 401 Unauthorized
```