### PR TITLE
Update fetch-depth for Auto

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v2
         with:
-          fetch-depth: 2
+          fetch-depth: 0
           token: ${{ secrets.AUTO_GITHUB_PAT_TOKEN }}
       - name: Build and Release
         uses: jupiterone/action-npm-build-release@v1


### PR DESCRIPTION
We used to only fetch the latest 2 commits for versioning since HEAD-1 was the tagged commit. This leads to Auto not having visibility on all commits. We now fetch the entire commit history to allow Auto to properly create the changelog.