### PR TITLE
feat(INT-6599): create document permissions script

### DIFF
--- a/commands/documentPermissions.ts
+++ b/commands/documentPermissions.ts
@@ -1,0 +1,107 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { Command } from 'commander';
+import { invocationConfig } from '../src';
+import { GoogleCloudIntegrationStep } from '../src/types';
+
+const table = require('markdown-table');
+
+const documentPermissionsCommand = new Command();
+
+interface DocumentCommandArgs {
+  outputFile: string;
+}
+
+const J1_PERMISSIONS_DOCUMENTATION_MARKER_START =
+  '<!-- {J1_PERMISSIONS_DOCUMENTATION_MARKER_START} -->';
+const J1_PERMISSIONS_DOCUMENTATION_MARKER_END =
+  '<!-- {J1_PERMISSIONS_DOCUMENTATION_MARKER_END} -->';
+
+documentPermissionsCommand
+  .command('documentPermissions')
+  .description('Generate GCP permissions list')
+  .option(
+    '-o, --output-file <path>',
+    'project relative path to generated Markdown file',
+    path.join('docs', 'jupiterone.md'),
+  )
+  .action(executeDocumentPermissionsAction);
+
+documentPermissionsCommand.parse();
+
+async function executeDocumentPermissionsAction(options: DocumentCommandArgs) {
+  const { outputFile } = options;
+  const documentationFilePath = path.join(process.cwd(), outputFile);
+  const oldDocumentationFile = await getDocumentationFile(
+    documentationFilePath,
+  );
+
+  const newGeneratedDocumentationSection = getNewDocumentationVersion();
+
+  if (!newGeneratedDocumentationSection) return;
+
+  const newDocumentationFile = replaceBetweenDocumentMarkers(
+    oldDocumentationFile,
+    newGeneratedDocumentationSection,
+  );
+
+  await fs.writeFile(documentationFilePath, newDocumentationFile, {
+    encoding: 'utf-8',
+  });
+}
+
+function getDocumentationFile(documentationFilePath: string): Promise<string> {
+  return fs.readFile(documentationFilePath, {
+    encoding: 'utf-8',
+  });
+}
+
+function getNewDocumentationVersion(): string | undefined {
+  const { integrationSteps } = invocationConfig;
+
+  const permissionsList = integrationSteps.reduce(
+    (accumulatedPermissions, step) => {
+      const googleCloudIntegrationStep = step as GoogleCloudIntegrationStep;
+      return googleCloudIntegrationStep.permissions
+        ? [...accumulatedPermissions, ...googleCloudIntegrationStep.permissions]
+        : accumulatedPermissions;
+    },
+    [] as string[],
+  );
+
+  const tableMarkdown = getTableMarkdown(permissionsList);
+
+  return `${J1_PERMISSIONS_DOCUMENTATION_MARKER_START}\n${tableMarkdown}\n${J1_PERMISSIONS_DOCUMENTATION_MARKER_END}`;
+}
+
+function getTableMarkdown(permissionsList: string[]): string {
+  return table([
+    ['Permissions List'],
+    ...permissionsList.map((permission) => [`\`${permission}\``]),
+  ]);
+}
+
+function replaceBetweenDocumentMarkers(
+  oldDocumentationFile: string,
+  newGeneratedDocumentationSection: string,
+): string {
+  const startIndex = oldDocumentationFile.indexOf(
+    J1_PERMISSIONS_DOCUMENTATION_MARKER_START,
+  );
+
+  if (startIndex === -1) {
+    return `${oldDocumentationFile}\n\n${newGeneratedDocumentationSection}`;
+  }
+
+  const endIndex = oldDocumentationFile.indexOf(
+    J1_PERMISSIONS_DOCUMENTATION_MARKER_END,
+  );
+
+  return (
+    oldDocumentationFile.substring(0, startIndex) +
+    newGeneratedDocumentationSection +
+    oldDocumentationFile.substring(
+      endIndex + J1_PERMISSIONS_DOCUMENTATION_MARKER_END.length,
+    )
+  );
+}

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -563,3 +563,12 @@ END OF GENERATED DOCUMENTATION AFTER BELOW MARKER
 <!-- {J1_DOCUMENTATION_MARKER_END} -->
 
 <!--  jupiterOneDocVersion=2-15-2-beta-4 -->
+
+#### Google Cloud Specific Permissions List
+
+If you prefer not to use Google managed roles, the following list of specific
+permissions can be used to provision only the required ones:
+
+<!-- {J1_PERMISSIONS_DOCUMENTATION_MARKER_START} -->
+
+<!-- {J1_PERMISSIONS_DOCUMENTATION_MARKER_END} -->

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "prepush": "yarn lint && yarn type-check && jest --changedSince main",
     "postversion": "cp package.json ./dist/package.json",
     "tf": "cd terraform && env `grep -v '^#' .env` terraform $1",
-    "create-env-file": "yarn ts-node ./scripts/createEnvFile $1"
+    "create-env-file": "yarn ts-node ./scripts/createEnvFile $1",
+    "document:permissions": " yarn ts-node commands/documentPermissions.ts documentPermissions"
   },
   "peerDependencies": {
     "@jupiterone/integration-sdk-core": "^8.24.1"
@@ -55,7 +56,8 @@
     "gaxios": "^4.2.1",
     "google-auth-library": "^7.1.0",
     "googleapis": "94.0.0",
-    "lodash.get": "^4.4.2"
+    "lodash.get": "^4.4.2",
+    "commander": "^9.4.1"
   },
   "auto": {
     "plugins": [

--- a/src/steps/access-context-manager/index.ts
+++ b/src/steps/access-context-manager/index.ts
@@ -2,12 +2,14 @@ import {
   createDirectRelationship,
   createMappedRelationship,
   Entity,
-  IntegrationStep,
   JobState,
   RelationshipClass,
   RelationshipDirection,
 } from '@jupiterone/integration-sdk-core';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { AccessContextManagerClient } from './client';
 import {
   STEP_ACCESS_CONTEXT_MANAGER_ACCESS_POLICIES,
@@ -383,7 +385,7 @@ export async function fetchServicePerimeters(
   );
 }
 
-export const accessPoliciesSteps: IntegrationStep<IntegrationConfig>[] = [
+export const accessPoliciesSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_ACCESS_CONTEXT_MANAGER_ACCESS_POLICIES,
     name: 'Access Context Manager Access Policies',

--- a/src/steps/api-gateway/index.ts
+++ b/src/steps/api-gateway/index.ts
@@ -1,10 +1,12 @@
 import {
   createDirectRelationship,
-  IntegrationStep,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import { apigateway_v1 } from 'googleapis';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { isMemberPublic } from '../../utils/iam';
 import { ApiGatewayClient } from './client';
 import {
@@ -181,7 +183,7 @@ export async function fetchApiGatewayGateways(
   });
 }
 
-export const apiGatewaySteps: IntegrationStep<IntegrationConfig>[] = [
+export const apiGatewaySteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_API_GATEWAY_APIS,
     name: 'Api Gateway APIs',

--- a/src/steps/app-engine/index.ts
+++ b/src/steps/app-engine/index.ts
@@ -4,12 +4,14 @@ import {
   Entity,
   getRawData,
   IntegrationLogger,
-  IntegrationStep,
   RelationshipClass,
   RelationshipDirection,
 } from '@jupiterone/integration-sdk-core';
 import { appengine_v1 } from 'googleapis';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { publishMissingPermissionEvent } from '../../utils/events';
 import { AppEngineClient } from './client';
 import {
@@ -377,7 +379,7 @@ export async function fetchAppEngineVersionInstances(
   );
 }
 
-export const appEngineSteps: IntegrationStep<IntegrationConfig>[] = [
+export const appEngineSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_APP_ENGINE_APPLICATION,
     name: 'AppEngine Application',

--- a/src/steps/big-query/index.ts
+++ b/src/steps/big-query/index.ts
@@ -1,12 +1,14 @@
 import {
   createDirectRelationship,
   createMappedRelationship,
-  IntegrationStep,
   RelationshipClass,
   RelationshipDirection,
 } from '@jupiterone/integration-sdk-core';
 import { bigquery_v2 } from 'googleapis';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { isMemberPublic } from '../../utils/iam';
 import { getKmsGraphObjectKeyFromKmsKeyName } from '../../utils/kms';
 import { ENTITY_TYPE_KMS_KEY, STEP_CLOUD_KMS_KEYS } from '../kms';
@@ -220,7 +222,7 @@ export async function fetchBigQueryTables(
   );
 }
 
-export const bigQuerySteps: IntegrationStep<IntegrationConfig>[] = [
+export const bigQuerySteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_BIG_QUERY_DATASETS,
     name: 'Big Query Datasets',

--- a/src/steps/big-table/index.ts
+++ b/src/steps/big-table/index.ts
@@ -1,9 +1,11 @@
 import {
   createDirectRelationship,
-  IntegrationStep,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { getKmsGraphObjectKeyFromKmsKeyName } from '../../utils/kms';
 import { ENTITY_TYPE_KMS_KEY, STEP_CLOUD_KMS_KEYS } from '../kms';
 import { BigTableClient } from './client';
@@ -219,7 +221,7 @@ export async function fetchTables(
   );
 }
 
-export const bigTableSteps: IntegrationStep<IntegrationConfig>[] = [
+export const bigTableSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_BIG_TABLE_INSTANCES,
     name: 'Bigtable Instances',

--- a/src/steps/billing-budgets/index.ts
+++ b/src/steps/billing-budgets/index.ts
@@ -1,11 +1,13 @@
 import {
   createDirectRelationship,
   createMappedRelationship,
-  IntegrationStep,
   RelationshipClass,
   RelationshipDirection,
 } from '@jupiterone/integration-sdk-core';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import {
   PROJECT_ENTITY_TYPE,
   STEP_RESOURCE_MANAGER_ORGANIZATION,
@@ -199,7 +201,7 @@ export async function buildAdditionalProjectBudgetRelationships(
   );
 }
 
-export const billingBudgetsSteps: IntegrationStep<IntegrationConfig>[] = [
+export const billingBudgetsSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_BILLING_BUDGETS,
     name: 'Billing Budgets',

--- a/src/steps/binary-authorization/index.ts
+++ b/src/steps/binary-authorization/index.ts
@@ -1,10 +1,12 @@
 import {
   createDirectRelationship,
-  IntegrationStep,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import { binaryauthorization_v1 } from 'googleapis';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import {
   PROJECT_ENTITY_TYPE,
   STEP_RESOURCE_MANAGER_PROJECT,
@@ -72,7 +74,7 @@ export async function fetchBinaryAuthorizationPolicy(
   }
 }
 
-export const binaryAuthorizationSteps: IntegrationStep<IntegrationConfig>[] = [
+export const binaryAuthorizationSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_BINARY_AUTHORIZATION_POLICY,
     name: 'Binary Authorization Policy',

--- a/src/steps/cloud-asset/index.ts
+++ b/src/steps/cloud-asset/index.ts
@@ -7,7 +7,6 @@ import {
   getRawData,
   IntegrationError,
   IntegrationLogger,
-  IntegrationStep,
   JobState,
   MappedRelationship,
   PrimitiveEntity,
@@ -16,8 +15,10 @@ import {
   RelationshipDirection,
 } from '@jupiterone/integration-sdk-core';
 import { cloudasset_v1, cloudresourcemanager_v3 } from 'googleapis';
-import { IntegrationConfig } from '../..';
-import { IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { publishMissingPermissionEvent } from '../../utils/events';
 import { getProjectIdFromName } from '../../utils/jobState';
 import { IAM_ROLE_ENTITY_CLASS, IAM_ROLE_ENTITY_TYPE } from '../iam';
@@ -792,7 +793,7 @@ export async function createApiServiceToAnyResourceRelationships(
   );
 }
 
-export const cloudAssetSteps: IntegrationStep<IntegrationConfig>[] = [
+export const cloudAssetSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_IAM_BINDINGS,
     name: 'IAM Bindings',

--- a/src/steps/cloud-billing/index.ts
+++ b/src/steps/cloud-billing/index.ts
@@ -1,5 +1,7 @@
-import { IntegrationStep } from '@jupiterone/integration-sdk-core';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { CloudBillingClient } from './client';
 import {
   STEP_BILLING_ACCOUNTS,
@@ -22,7 +24,7 @@ export async function fetchBillingAccounts(
   });
 }
 
-export const cloudBillingSteps: IntegrationStep<IntegrationConfig>[] = [
+export const cloudBillingSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_BILLING_ACCOUNTS,
     name: 'Billing Accounts',

--- a/src/steps/cloud-build/index.ts
+++ b/src/steps/cloud-build/index.ts
@@ -1,5 +1,4 @@
-import { IntegrationStep } from '@jupiterone/integration-sdk-core';
-import { IntegrationConfig } from '../../types';
+import { GoogleCloudIntegrationStep } from '../../types';
 import { buildCloudBuildTriggerTriggersBuildRelationshipsStep } from './steps/build-cloud-build-trigger-triggers-build-relationships';
 import { buildCloudBuildTriggerUsesGithubRepositoryStep } from './steps/build-cloud-build-trigger-uses-github-repo-relationships';
 import { buildCloudBuildUsesSourceRepositoryRelationshipsStep } from './steps/build-cloud-build-uses-source-repo-relationships';
@@ -11,7 +10,7 @@ import { fetchCloudBuildTriggerStep } from './steps/fetch-cloud-build-triggers';
 import { fetchCloudBuildWorkerPoolsStep } from './steps/fetch-cloud-build-worker-pools';
 import { fetchCloudBuildStep } from './steps/fetch-cloud-builds';
 
-export const cloudBuildSteps: IntegrationStep<IntegrationConfig>[] = [
+export const cloudBuildSteps: GoogleCloudIntegrationStep[] = [
   fetchCloudBuildStep,
   fetchCloudBuildTriggerStep,
   fetchCloudBuildWorkerPoolsStep,

--- a/src/steps/cloud-run/index.ts
+++ b/src/steps/cloud-run/index.ts
@@ -1,9 +1,11 @@
 import {
   createDirectRelationship,
-  IntegrationStep,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import {
   cacheCloudRunServiceKeyAndUid,
   getCloudRunServiceKeyFromUid,
@@ -145,7 +147,7 @@ export async function fetchCloudRunConfigurations(
   });
 }
 
-export const cloudRunSteps: IntegrationStep<IntegrationConfig>[] = [
+export const cloudRunSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_CLOUD_RUN_SERVICES,
     name: 'Cloud Run Services',

--- a/src/steps/cloud-source-repositories/index.ts
+++ b/src/steps/cloud-source-repositories/index.ts
@@ -1,6 +1,6 @@
-import { IntegrationStep } from '@jupiterone/integration-sdk-core';
-import { IntegrationConfig } from '../../types';
+import { GoogleCloudIntegrationStep } from '../../types';
 import { fetchCloudSourceRepositoriesStep } from './steps/fetch-cloud-source-repositories';
 
-export const cloudSourceRepositoriesSteps: IntegrationStep<IntegrationConfig>[] =
-  [fetchCloudSourceRepositoriesStep];
+export const cloudSourceRepositoriesSteps: GoogleCloudIntegrationStep[] = [
+  fetchCloudSourceRepositoriesStep,
+];

--- a/src/steps/compute/index.ts
+++ b/src/steps/compute/index.ts
@@ -1,5 +1,4 @@
 import {
-  IntegrationStep,
   JobState,
   Entity,
   createDirectRelationship,
@@ -8,7 +7,10 @@ import {
   getRawData,
 } from '@jupiterone/integration-sdk-core';
 import { ComputeClient } from './client';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import {
   createComputeDiskEntity,
   createComputeInstanceEntity,
@@ -1877,7 +1879,7 @@ export async function fetchComputeSslPolicies(
   });
 }
 
-export const computeSteps: IntegrationStep<IntegrationConfig>[] = [
+export const computeSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_COMPUTE_NETWORKS,
     name: 'Compute Networks',

--- a/src/steps/containers/index.ts
+++ b/src/steps/containers/index.ts
@@ -1,9 +1,11 @@
 import {
   createDirectRelationship,
-  IntegrationStep,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import {
   ENTITY_TYPE_COMPUTE_INSTANCE_GROUP,
   STEP_COMPUTE_INSTANCE_GROUPS,
@@ -96,7 +98,7 @@ export async function fetchContainerClusters(
   });
 }
 
-export const containerSteps: IntegrationStep<IntegrationConfig>[] = [
+export const containerSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_CONTAINER_CLUSTERS,
     name: 'Container Clusters',

--- a/src/steps/dataproc/index.ts
+++ b/src/steps/dataproc/index.ts
@@ -2,12 +2,14 @@ import {
   createDirectRelationship,
   createMappedRelationship,
   getRawData,
-  IntegrationStep,
   RelationshipClass,
   RelationshipDirection,
 } from '@jupiterone/integration-sdk-core';
 import { dataproc_v1 } from 'googleapis';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { getKmsGraphObjectKeyFromKmsKeyName } from '../../utils/kms';
 import { ENTITY_TYPE_COMPUTE_IMAGE, STEP_COMPUTE_IMAGES } from '../compute';
 import { ENTITY_TYPE_KMS_KEY, STEP_CLOUD_KMS_KEYS } from '../kms';
@@ -183,7 +185,7 @@ export async function createClusterStorageRelationships(
   );
 }
 
-export const dataprocSteps: IntegrationStep<IntegrationConfig>[] = [
+export const dataprocSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_DATAPROC_CLUSTERS,
     name: 'Dataproc Clusters',

--- a/src/steps/dns/index.ts
+++ b/src/steps/dns/index.ts
@@ -1,9 +1,11 @@
 import {
   createDirectRelationship,
-  IntegrationStep,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { ENTITY_TYPE_COMPUTE_NETWORK, STEP_COMPUTE_NETWORKS } from '../compute';
 import { DNSClient } from './client';
 import {
@@ -71,7 +73,7 @@ export async function fetchDNSPolicies(
   });
 }
 
-export const dnsManagedZonesSteps: IntegrationStep<IntegrationConfig>[] = [
+export const dnsManagedZonesSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_DNS_MANAGED_ZONES,
     name: 'DNS Managed Zones',

--- a/src/steps/functions/index.ts
+++ b/src/steps/functions/index.ts
@@ -1,11 +1,13 @@
 import {
   createDirectRelationship,
   getRawData,
-  IntegrationStep,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import { CloudFunctionsClient } from './client';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { createCloudFunctionEntity } from './converters';
 import { STEP_IAM_SERVICE_ACCOUNTS } from '../iam';
 import {
@@ -145,7 +147,7 @@ export async function buildCloudFunctionStorageBucketRelationships(
   );
 }
 
-export const functionsSteps: IntegrationStep<IntegrationConfig>[] = [
+export const functionsSteps: GoogleCloudIntegrationStep[] = [
   {
     id: FunctionStepsSpec.FETCH_CLOUD_FUNCTIONS.id,
     name: FunctionStepsSpec.FETCH_CLOUD_FUNCTIONS.name,

--- a/src/steps/iam/index.ts
+++ b/src/steps/iam/index.ts
@@ -1,11 +1,13 @@
 import {
   createDirectRelationship,
   IntegrationLogger,
-  IntegrationStep,
   JobState,
 } from '@jupiterone/integration-sdk-core';
 import { IamClient } from './client';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import {
   createIamRoleEntity,
   createIamServiceAccountEntity,
@@ -228,7 +230,7 @@ export async function fetchIamServiceAccounts(
   });
 }
 
-export const iamSteps: IntegrationStep<IntegrationConfig>[] = [
+export const iamSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_IAM_CUSTOM_ROLES,
     name: 'Identity and Access Management (IAM) Custom Roles',

--- a/src/steps/kms/index.ts
+++ b/src/steps/kms/index.ts
@@ -1,10 +1,12 @@
 import {
   createDirectRelationship,
-  IntegrationStep,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import { CloudKmsClient } from './client';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import {
   ENTITY_CLASS_KMS_KEY,
   ENTITY_CLASS_KMS_KEY_RING,
@@ -24,22 +26,25 @@ export async function fetchKmsKeyRings(
   const { jobState, instance, logger } = context;
   const client = new CloudKmsClient({ config: instance.config });
 
-  await client.iterateKeyRings(async (keyRing) => {
-    await jobState.addEntity(createKmsKeyRingEntity(keyRing));
-  }, ({ 
-    totalRequestsMade,
-    totalResourcesReturned,
-    maximumResourcesPerPage
-   }) => {
-    logger.info(
-      {
-        totalRequestsMade,
-        totalResourcesReturned,
-        maximumResourcesPerPage
-      },
-      'KMS Key Rings API Requests summary',
-    );
-  });
+  await client.iterateKeyRings(
+    async (keyRing) => {
+      await jobState.addEntity(createKmsKeyRingEntity(keyRing));
+    },
+    ({
+      totalRequestsMade,
+      totalResourcesReturned,
+      maximumResourcesPerPage,
+    }) => {
+      logger.info(
+        {
+          totalRequestsMade,
+          totalResourcesReturned,
+          maximumResourcesPerPage,
+        },
+        'KMS Key Rings API Requests summary',
+      );
+    },
+  );
 }
 
 export async function fetchKmsCryptoKeys(
@@ -90,7 +95,7 @@ export async function fetchKmsCryptoKeys(
   );
 }
 
-export const kmsSteps: IntegrationStep<IntegrationConfig>[] = [
+export const kmsSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_CLOUD_KMS_KEY_RINGS,
     name: 'KMS Key Rings',

--- a/src/steps/logging/index.ts
+++ b/src/steps/logging/index.ts
@@ -1,10 +1,12 @@
 import {
   createDirectRelationship,
   getRawData,
-  IntegrationStep,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { LoggingClient } from './client';
 import {
   LOGGING_METRIC_ENTITY_CLASS,
@@ -139,7 +141,7 @@ export async function fetchMetrics(
   });
 }
 
-export const loggingSteps: IntegrationStep<IntegrationConfig>[] = [
+export const loggingSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_LOGGING_PROJECT_SINKS,
     name: 'Logging Project Sinks',

--- a/src/steps/memcache/index.ts
+++ b/src/steps/memcache/index.ts
@@ -1,11 +1,13 @@
 import {
   createDirectRelationship,
   getRawData,
-  IntegrationStep,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import { memcache_v1 } from 'googleapis';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { ENTITY_TYPE_COMPUTE_NETWORK, STEP_COMPUTE_NETWORKS } from '../compute';
 import { MemcacheClient } from './client';
 import {
@@ -104,7 +106,7 @@ export async function buildMemcacheInstancesUsesNetworkRelationships(
   );
 }
 
-export const memcacheSteps: IntegrationStep<IntegrationConfig>[] = [
+export const memcacheSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_MEMCACHE_INSTANCES,
     name: 'Memcache Instances',

--- a/src/steps/monitoring/index.ts
+++ b/src/steps/monitoring/index.ts
@@ -1,5 +1,7 @@
-import { IntegrationStep } from '@jupiterone/integration-sdk-core';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { publishUnsupportedConfigEvent } from '../../utils/events';
 import { MonitoringClient } from './client';
 import {
@@ -39,7 +41,7 @@ export async function fetchAlertPolicies(
   }
 }
 
-export const monitoringSteps: IntegrationStep<IntegrationConfig>[] = [
+export const monitoringSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_MONITORING_ALERT_POLICIES,
     name: 'Monitoring Alert Policies',

--- a/src/steps/privateca/index.ts
+++ b/src/steps/privateca/index.ts
@@ -1,11 +1,13 @@
 import {
   createDirectRelationship,
   getRawData,
-  IntegrationStep,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import { privateca_v1beta1 } from 'googleapis';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { isMemberPublic } from '../../utils/iam';
 import { PrivateCaClient } from './client';
 import {
@@ -158,7 +160,7 @@ export async function fetchAuthorityCertificates(
   );
 }
 
-export const privateCaSteps: IntegrationStep<IntegrationConfig>[] = [
+export const privateCaSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_PRIVATE_CA_CERTIFICATE_AUTHORITIES,
     name: 'Private CA Certificate Authorities',

--- a/src/steps/pub-sub/index.ts
+++ b/src/steps/pub-sub/index.ts
@@ -2,12 +2,14 @@ import {
   createDirectRelationship,
   createMappedRelationship,
   getRawData,
-  IntegrationStep,
   RelationshipClass,
   RelationshipDirection,
 } from '@jupiterone/integration-sdk-core';
 import { pubsub_v1 } from 'googleapis';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { ENTITY_TYPE_KMS_KEY, STEP_CLOUD_KMS_KEYS } from '../kms';
 import { PubSubClient } from './client';
 import {
@@ -162,7 +164,7 @@ export async function fetchPubSubSubscriptions(
   });
 }
 
-export const pubSubSteps: IntegrationStep<IntegrationConfig>[] = [
+export const pubSubSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_PUBSUB_TOPICS,
     name: 'PubSub Topics',

--- a/src/steps/redis/index.ts
+++ b/src/steps/redis/index.ts
@@ -1,10 +1,12 @@
 import {
   createDirectRelationship,
   getRawData,
-  IntegrationStep,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { STEP_COMPUTE_NETWORKS } from '../compute';
 import { RedisClient } from './client';
 import {
@@ -78,7 +80,7 @@ export async function buildRedisInstanceUsesNetworkRelationships(
   );
 }
 
-export const redisSteps: IntegrationStep<IntegrationConfig>[] = [
+export const redisSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_REDIS_INSTANCES,
     name: 'Redis Instances',

--- a/src/steps/resource-manager/index.ts
+++ b/src/steps/resource-manager/index.ts
@@ -1,12 +1,14 @@
 import {
-  IntegrationStep,
   Entity,
   createDirectRelationship,
   createMappedRelationship,
   RelationshipDirection,
 } from '@jupiterone/integration-sdk-core';
 import { ResourceManagerClient } from './client';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import {
   createAuditConfigEntity,
   createFolderEntity,
@@ -347,7 +349,7 @@ export async function fetchIamPolicyAuditConfig(
   });
 }
 
-export const resourceManagerSteps: IntegrationStep<IntegrationConfig>[] = [
+export const resourceManagerSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_RESOURCE_MANAGER_ORGANIZATION,
     name: 'Resource Manager Organization',

--- a/src/steps/secret-manager/index.ts
+++ b/src/steps/secret-manager/index.ts
@@ -1,11 +1,13 @@
 import {
   createDirectRelationship,
   getRawData,
-  IntegrationStep,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import { secretmanager_v1 } from 'googleapis';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { SecretManagerClient } from './client';
 import {
   SecretManagerEntities,
@@ -58,7 +60,7 @@ export async function fetchSecretVersions(
   );
 }
 
-export const secretManagerSteps: IntegrationStep<IntegrationConfig>[] = [
+export const secretManagerSteps: GoogleCloudIntegrationStep[] = [
   {
     ...SecretManagerSteps.FETCH_SECRETS,
     entities: [SecretManagerEntities.SECRET],

--- a/src/steps/service-usage/index.ts
+++ b/src/steps/service-usage/index.ts
@@ -1,10 +1,12 @@
 import {
-  IntegrationStep,
   createDirectRelationship,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import { ServiceUsageClient } from './client';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { createApiServiceEntity } from './converters';
 import {
   ServiceUsageStepIds,
@@ -103,7 +105,7 @@ export async function fetchApiServices(
   );
 }
 
-export const serviceUsageSteps: IntegrationStep<IntegrationConfig>[] = [
+export const serviceUsageSteps: GoogleCloudIntegrationStep[] = [
   {
     id: ServiceUsageStepIds.FETCH_API_SERVICES,
     name: 'API Services',

--- a/src/steps/spanner/index.ts
+++ b/src/steps/spanner/index.ts
@@ -1,12 +1,14 @@
 import {
   createDirectRelationship,
   createMappedRelationship,
-  IntegrationStep,
   RelationshipClass,
   RelationshipDirection,
 } from '@jupiterone/integration-sdk-core';
 import { spanner_v1 } from 'googleapis';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { isMemberPublic } from '../../utils/iam';
 import { getKmsGraphObjectKeyFromKmsKeyName } from '../../utils/kms';
 import { RELATIONSHIP_TYPE_DATASET_USES_KMS_CRYPTO_KEY } from '../big-query';
@@ -174,7 +176,7 @@ export async function fetchSpannerInstanceDatabases(
   );
 }
 
-export const spannerSteps: IntegrationStep<IntegrationConfig>[] = [
+export const spannerSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_SPANNER_INSTANCE_CONFIGS,
     name: 'Spanner Instance Configs',

--- a/src/steps/sql-admin/index.ts
+++ b/src/steps/sql-admin/index.ts
@@ -3,11 +3,13 @@ import {
   createDirectRelationship,
   createMappedRelationship,
   getRawData,
-  IntegrationStep,
   RelationshipClass,
   RelationshipDirection,
 } from '@jupiterone/integration-sdk-core';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { getKmsGraphObjectKeyFromKmsKeyName } from '../../utils/kms';
 import {
   ENTITY_TYPE_KMS_KEY,
@@ -154,7 +156,7 @@ export async function buildSqlAdminInstanceKmsKeyRelationships(
   }
 }
 
-export const sqlAdminSteps: IntegrationStep<IntegrationConfig>[] = [
+export const sqlAdminSteps: GoogleCloudIntegrationStep[] = [
   {
     id: STEP_SQL_ADMIN_INSTANCES,
     name: 'SQL Admin Instances',

--- a/src/steps/steps.ts
+++ b/src/steps/steps.ts
@@ -1,11 +1,10 @@
 import {
   ExecutionHandlerFunction,
   IntegrationProviderAuthorizationError,
-  IntegrationStep,
   StepExecutionContext,
 } from '@jupiterone/integration-sdk-core';
 import { createErrorProps } from '../google-cloud/utils/createErrorProps';
-import { IntegrationConfig } from '../types';
+import { GoogleCloudIntegrationStep } from '../types';
 import { accessPoliciesSteps } from './access-context-manager';
 import { apiGatewaySteps } from './api-gateway';
 import { appEngineSteps } from './app-engine';
@@ -38,7 +37,7 @@ import { spannerSteps } from './spanner';
 import { sqlAdminSteps } from './sql-admin';
 import { storageSteps } from './storage';
 
-const steps: IntegrationStep<IntegrationConfig>[] = wrapStepExecutionHandlers([
+const steps: GoogleCloudIntegrationStep[] = wrapStepExecutionHandlers([
   ...functionsSteps,
   ...storageSteps,
   ...serviceUsageSteps,
@@ -73,8 +72,8 @@ const steps: IntegrationStep<IntegrationConfig>[] = wrapStepExecutionHandlers([
 ]);
 
 function wrapStepExecutionHandlers(
-  steps: IntegrationStep<IntegrationConfig>[],
-): IntegrationStep<IntegrationConfig>[] {
+  steps: GoogleCloudIntegrationStep[],
+): GoogleCloudIntegrationStep[] {
   return steps.map((step) => {
     step.executionHandler;
     return {

--- a/src/steps/storage/index.ts
+++ b/src/steps/storage/index.ts
@@ -1,6 +1,8 @@
-import { IntegrationStep } from '@jupiterone/integration-sdk-core';
 import { CloudStorageClient } from './client';
-import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import {
+  GoogleCloudIntegrationStep,
+  IntegrationStepContext,
+} from '../../types';
 import { createCloudStorageBucketEntity } from './converters';
 import { StorageStepsSpec, StorageEntitiesSpec } from './constants';
 import { storage_v1 } from 'googleapis';
@@ -94,7 +96,7 @@ export async function fetchStorageBuckets(
   }
 }
 
-export const storageSteps: IntegrationStep<IntegrationConfig>[] = [
+export const storageSteps: GoogleCloudIntegrationStep[] = [
   {
     id: StorageStepsSpec.FETCH_STORAGE_BUCKETS.id,
     name: StorageStepsSpec.FETCH_STORAGE_BUCKETS.name,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import {
   IntegrationInstanceConfig,
+  IntegrationStep,
   IntegrationStepExecutionContext,
 } from '@jupiterone/integration-sdk-core';
 import { ParsedServiceAccountKeyFile } from './utils/parseServiceAccountKeyFile';
@@ -30,4 +31,9 @@ export interface IntegrationConfig extends SerializedIntegrationConfig {
   serviceAccountKeyConfig: ParsedServiceAccountKeyFile;
   // HACK - used to prevent binding step ingestion for large accounts. Think twice before using.
   markBindingStepsAsPartial?: boolean;
+}
+
+export interface GoogleCloudIntegrationStep
+  extends IntegrationStep<IntegrationConfig> {
+  permissions?: Array<string>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2150,6 +2150,11 @@ commander@^9.4.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
   integrity sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==
 
+commander@^9.4.1:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
+  integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
+
 compare-versions@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"


### PR DESCRIPTION
## Create Document permissions script 

### Context and motivation: 

We must provide the required list of permissions that require a review of all the SDK calls that we are doing and collect all of them. As part of making this process more scalable, this spike ticket was created, in order to investigate a way to automate the process of collecting this permissions and adding this to `jupiterone.md` README automatically. This script might be migrated to the SDK in the future to apply this process to all services. 

### How it works

`yarn document:permissions` command was added. This script imports `invocationConfig` variable from steps index to be able to collect permissions. This permissions will be added to the `IntegrationStep` array in each step as permissions. This would look like this:

```
{
    id: ...,
    name: ...,
    dependsOn: [],
    entities: [],
    relationships: [],
    executionHandler: () => {},
    permissions: ['permission1', 'permission2'],
},
```

And will produce a new section in `jupiterone.md` documentation:

<img width="475" alt="Screen Shot 2023-01-09 at 11 01 20" src="https://user-images.githubusercontent.com/13191932/211333547-5cfb2578-72e2-4456-8faa-772424d610a8.png">

