### PR TITLE
fix(INT-6744): add debug log if timeout error

### DIFF
--- a/src/steps/cloud-build/client.ts
+++ b/src/steps/cloud-build/client.ts
@@ -1,7 +1,7 @@
 import { cloudbuild_v1, google } from 'googleapis';
 import { Client } from '../../google-cloud/client';
 import { IntegrationStepContext } from '../../types';
-import { CloudBuildLocations } from './constants';
+import { CloudBuildEntitiesSpec, CloudBuildLocations } from './constants';
 
 export class CloudBuildClient extends Client {
   private client = google.cloudbuild({ version: 'v1' });
@@ -129,29 +129,41 @@ export class CloudBuildClient extends Client {
 
   async iterateBuildBitbucketRepositories(
     serverConfig: cloudbuild_v1.Schema$BitbucketServerConfig,
+    context: IntegrationStepContext,
     callback: (
       data: cloudbuild_v1.Schema$BitbucketServerRepository,
     ) => Promise<void>,
   ): Promise<void> {
     const auth = await this.getAuthenticatedServiceClient();
 
-    await this.iterateApi(
-      (nextPageToken) => {
-        return this.client.projects.locations.bitbucketServerConfigs.repos.list(
-          {
-            auth,
-            pageToken: nextPageToken,
-            parent: serverConfig.name!,
-          },
+    try {
+      await this.iterateApi(
+        (nextPageToken) => {
+          return this.client.projects.locations.bitbucketServerConfigs.repos.list(
+            {
+              auth,
+              pageToken: nextPageToken,
+              parent: serverConfig.name!,
+            },
+          );
+        },
+        async (
+          data: cloudbuild_v1.Schema$ListBitbucketServerRepositoriesResponse,
+        ) => {
+          for (const config of data.bitbucketServerRepositories || []) {
+            await callback(config);
+          }
+        },
+      );
+    } catch (err) {
+      if (err.code === 'ATTEMPT_TIMEOUT') {
+        context.logger.warn(
+          { err },
+          `${CloudBuildEntitiesSpec.BUILD_BITBUCKET_SERVER_CONFIG._type} - Unable to fetch BitBucket repositories. This might be caused by expired credentials in the GCP console (Cloud Build).`,
         );
-      },
-      async (
-        data: cloudbuild_v1.Schema$ListBitbucketServerRepositoriesResponse,
-      ) => {
-        for (const config of data.bitbucketServerRepositories || []) {
-          await callback(config);
-        }
-      },
-    );
+      }
+
+      throw err;
+    }
   }
 }

--- a/src/steps/cloud-build/client.ts
+++ b/src/steps/cloud-build/client.ts
@@ -161,9 +161,9 @@ export class CloudBuildClient extends Client {
           { err },
           `${CloudBuildEntitiesSpec.BUILD_BITBUCKET_SERVER_CONFIG._type} - Unable to fetch BitBucket repositories. This might be caused by expired credentials in the GCP console (Cloud Build).`,
         );
+      } else {
+        throw err;
       }
-
-      throw err;
     }
   }
 }

--- a/src/steps/cloud-build/steps/fetch-cloud-build-bb-repos.ts
+++ b/src/steps/cloud-build/steps/fetch-cloud-build-bb-repos.ts
@@ -27,7 +27,6 @@ export const fetchCloudBuildBitbucketRepositoriesStep: GoogleCloudIntegrationSte
       context: IntegrationStepContext,
     ): Promise<void> {
       const {
-        logger,
         jobState,
         instance: { config },
       } = context;
@@ -41,31 +40,22 @@ export const fetchCloudBuildBitbucketRepositoriesStep: GoogleCloudIntegrationSte
               serverConfigEntity,
             );
 
-          try {
-            await client.iterateBuildBitbucketRepositories(
-              serverConfig!,
-              async (repository) => {
-                const repositoryEntity =
-                  createGoogleCloudBuildBitbucketRepoEntity(repository);
-                await jobState.addEntity(repositoryEntity);
-                await jobState.addRelationship(
-                  createDirectRelationship({
-                    _class: RelationshipClass.HAS,
-                    from: serverConfigEntity,
-                    to: repositoryEntity,
-                  }),
-                );
-              },
-            );
-          } catch (err) {
-            if (err.code === 'ATTEMPT_TIMEOUT') {
-              logger.warn(
-                `${CloudBuildEntitiesSpec.BUILD_BITBUCKET_SERVER_CONFIG._type} - Unable to fetch BitBucket repositories. This might be caused by expired credentials in the GCP console (Cloud Build).`,
+          await client.iterateBuildBitbucketRepositories(
+            serverConfig!,
+            context,
+            async (repository) => {
+              const repositoryEntity =
+                createGoogleCloudBuildBitbucketRepoEntity(repository);
+              await jobState.addEntity(repositoryEntity);
+              await jobState.addRelationship(
+                createDirectRelationship({
+                  _class: RelationshipClass.HAS,
+                  from: serverConfigEntity,
+                  to: repositoryEntity,
+                }),
               );
-            }
-
-            throw err;
-          }
+            },
+          );
         },
       );
     },


### PR DESCRIPTION
## Add debug log if timeout error

Context: 

Google Cloud does not handle correctly errors when BitBucket credentials are expired. Added a log in order to make it more easy to debug in the future. 