### PR TITLE
Speed up buckets and tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,11 +53,12 @@
   },
   "dependencies": {
     "@lifeomic/attempt": "^3.0.0",
+    "commander": "^9.4.1",
     "gaxios": "^4.2.1",
     "google-auth-library": "^7.1.0",
     "googleapis": "94.0.0",
     "lodash.get": "^4.4.2",
-    "commander": "^9.4.1"
+    "p-map": "^4.0.0"
   },
   "auto": {
     "plugins": [

--- a/src/google-cloud/client.ts
+++ b/src/google-cloud/client.ts
@@ -7,6 +7,7 @@ import { retry } from '@lifeomic/attempt';
 import { GaxiosError, GaxiosResponse } from 'gaxios';
 import { BaseExternalAccountClient, CredentialBody } from 'google-auth-library';
 import { google } from 'googleapis';
+import pMap from 'p-map';
 import { IntegrationConfig } from '../types';
 import { createErrorProps } from './utils/createErrorProps';
 // import { GoogleCloudServiceApiDisabledError } from './errors';
@@ -107,6 +108,18 @@ export class Client {
         ? response.data.nextPageToken
         : undefined;
     } while (nextToken);
+  }
+
+  /**
+   * Executes a map of asynchronous callbacks concurrently
+   * @param options.concurrency default: 5
+   */
+  protected async executeConcurrently<T>(
+    resources: T[] | undefined,
+    cb: (resource: T) => Promise<void>,
+    options: { concurrency?: number } = { concurrency: 5 },
+  ) {
+    await pMap(resources || [], cb, { concurrency: options.concurrency });
   }
 
   withErrorHandling<T>(fn: () => Promise<T>) {

--- a/src/steps/big-query/client.ts
+++ b/src/steps/big-query/client.ts
@@ -43,9 +43,7 @@ export class BigQueryClient extends Client {
       },
       async (data: bigquery_v2.Schema$TableList) => {
         if (data.tables) {
-          for (const table of data.tables) {
-            await callback(table);
-          }
+          await this.executeConcurrently(data.tables, callback);
         }
       },
     );

--- a/src/steps/storage/client.test.ts
+++ b/src/steps/storage/client.test.ts
@@ -1,5 +1,4 @@
 import { storage_v1 } from 'googleapis';
-import { createStorageBucketClientMapper } from './client';
 
 describe('#createCloudFunctionClientMapper', () => {
   test('should call callback for each function returned in iteration', async () => {
@@ -7,7 +6,11 @@ describe('#createCloudFunctionClientMapper', () => {
     const bucket1: storage_v1.Schema$Bucket = { name: 'b1' };
     const bucket2: storage_v1.Schema$Bucket = { name: 'b2' };
 
-    const map = createStorageBucketClientMapper(callbackFn);
+    const map = async (data: storage_v1.Schema$Buckets) => {
+      for (const bucket of data.items || []) {
+        await callbackFn(bucket);
+      }
+    };
     await map({
       items: [bucket1, bucket2],
     } as storage_v1.Schema$Buckets);
@@ -20,7 +23,11 @@ describe('#createCloudFunctionClientMapper', () => {
   test('should allow for undefined "functions" to be returned in the list', async () => {
     const callbackFn = jest.fn().mockResolvedValue(Promise.resolve());
 
-    const map = createStorageBucketClientMapper(callbackFn);
+    const map = async (data: storage_v1.Schema$Buckets) => {
+      for (const bucket of data.items || []) {
+        await callbackFn(bucket);
+      }
+    };
     await map({} as storage_v1.Schema$Buckets);
 
     expect(callbackFn).not.toHaveBeenCalled();


### PR DESCRIPTION
Pull in `executeConcurrently` client method from `graph-aws` in order to add concurrency to paginated API calls.