### PR TITLE
INT-7798: fix org steps running with undefined project id

### DIFF
--- a/src/utils/isSingleProjectInstance.ts
+++ b/src/utils/isSingleProjectInstance.ts
@@ -6,9 +6,5 @@ import { SerializedIntegrationConfig } from '../types';
 export function isSingleProjectInstance(
   config: SerializedIntegrationConfig,
 ): boolean {
-  return (
-    Boolean(config.projectId) &&
-    !config.configureOrganizationProjects &&
-    !config.organizationId
-  );
+  return !config.configureOrganizationProjects && !config.organizationId;
 }


### PR DESCRIPTION
Fix org steps running with undefined project id. This issue was caused by an `undefined` project id config that is possible scenario. 