### PR TITLE
Mapping Updates 3.5-7.1 questions(GCP 1.3.0/2.0.0)

### DIFF
--- a/jupiterone/questions/questions.yaml
+++ b/jupiterone/questions/questions.yaml
@@ -496,6 +496,15 @@ questions:
   - dns
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '3.5'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '3.5'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '3.5'
 
@@ -533,6 +542,15 @@ questions:
   - network
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '3.6'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '3.6'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '3.6'
 
@@ -570,6 +588,15 @@ questions:
   - network
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '3.7'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '3.7'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '3.7'
 
@@ -661,6 +688,15 @@ questions:
   - service-account
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '4.1'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '4.1'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '4.1'
 
@@ -705,6 +741,15 @@ questions:
   - instance
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '4.3'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '4.3'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '4.3'
 
@@ -739,6 +784,15 @@ questions:
   - project
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '4.4'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '4.4'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '4.4'
 
@@ -764,6 +818,15 @@ questions:
   - compute
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '4.5'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '4.5'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '4.5'
 
@@ -791,6 +854,15 @@ questions:
   - network
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '4.6'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '4.6'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '4.6'
 
@@ -811,6 +883,15 @@ questions:
   - encryption
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '4.7'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '4.7'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '4.7'
 
@@ -830,6 +911,15 @@ questions:
   - compute
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '4.8'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '4.8'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '4.8'
 ################################################################################
@@ -855,6 +945,15 @@ questions:
   - access
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '5.1'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '5.1'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '5.1'
 - id: integration-question-google-cloud-storage-bucket-uniform-bucket-access-enabled
@@ -873,8 +972,18 @@ questions:
   - access
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
     requirements:
       - '5.2'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '5.2'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
+    requirements:
+      - '5.2'
+
 ################################################################################
 # End Section 5: Storage
 ################################################################################
@@ -942,6 +1051,15 @@ questions:
   - datastore
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '6.2.2'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '6.2.2'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '6.2.2'
 
@@ -963,6 +1081,15 @@ questions:
   - datastore
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '6.2.3'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '6.2.3'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '6.2.3'
 
@@ -1122,6 +1249,15 @@ questions:
   - network
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '6.4'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '6.4'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '6.4'
 
@@ -1145,8 +1281,17 @@ questions:
   - network
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
     requirements:
       - '6.5'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '7.1'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
+    requirements:
+      - '7.1'
 
 - id: integration-question-google-sql-public-ips
   title: Do my Cloud SQL instances have public IP addresses?
@@ -1168,6 +1313,15 @@ questions:
   - network
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '6.6'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '6.6'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '6.6'
 
@@ -1191,6 +1345,15 @@ questions:
   - network
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '6.7'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '6.7'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '6.7'
 ################################################################################
@@ -1217,6 +1380,15 @@ questions:
   - datastore
   compliance:
   - standard: CIS Google Cloud Foundations 1.1
+    version: v1.1.0
+    requirements:
+      - '7.1'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 1.3
+    version: v1.3.0
+    requirements:
+      - '7.1'
+  - standard: CIS Google Cloud Platform Foundation Benchmark 2.0.0
+    version: v2.0.0
     requirements:
       - '7.1'
 ################################################################################


### PR DESCRIPTION
This PR Updates question 3.5-7.1 to include GCP 1.3.0/2.0.0 mapping for Questions that are applicable from 1.1.0